### PR TITLE
added value bootsrapping on time_out

### DIFF
--- a/rl_games/common/a2c_common.py
+++ b/rl_games/common/a2c_common.py
@@ -518,6 +518,9 @@ class A2CBase:
 
             self.obs, rewards, self.dones, infos = self.env_step(res_dict['action'])
 
+            if 'time_outs' in infos:
+                rewards += self.gamma * res_dict['value'] * infos['time_outs'].to(self.ppo_device)
+
             shaped_rewards = self.rewards_shaper(rewards)
             mb_rewards[n,:] = shaped_rewards
 
@@ -617,6 +620,9 @@ class A2CBase:
                 mb_vobs[indices[::self.num_agents] ,play_mask[::self.num_agents]//self.num_agents] = self.obs['states']
 
             self.obs, rewards, self.dones, infos = self.env_step(res_dict['action'])
+
+            if 'time_outs' in infos:
+                rewards += self.gamma * res_dict['value'] * infos['time_outs'].to(self.ppo_device)
 
             shaped_rewards = self.rewards_shaper(rewards)
 


### PR DESCRIPTION
Added the bootstrapping of rewards with critic predictions on resets caused by time_outs. This greatly improves the training performance for envs where most resets are due to time outs. it is only applied if a 'time_out' tensor is returned in info, so should be compatible with all other envs.