### PR TITLE
Add wandb integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,18 @@ poetry run python runner.py --train --file rl_games/configs/brax/ppo_ant.yaml
 poetry run python runner.py --play --file rl_games/configs/brax/ppo_ant.yaml --checkpoint runs/Ant_brax/nn/Ant_brax.pth
 ```
 
+## Experiment tracking
+
+rl_games support experiment tracking with [Weights and Biases](https://wandb.ai).
+
+```bash
+poetry install -E atari
+poetry run python runner.py --train --file rl_games/configs/atari/ppo_breakout_torch.yaml --track
+WANDB_API_KEY=xxxx poetry run python runner.py --train --file rl_games/configs/atari/ppo_breakout_torch.yaml --track
+poetry run python runner.py --train --file rl_games/configs/atari/ppo_breakout_torch.yaml --wandb-project-name rl-games-special-test --track
+poetry run python runner.py --train --file rl_games/configs/atari/ppo_breakout_torch.yaml --wandb-project-name rl-games-special-test -wandb-entity openrlbenchmark --track
+```
+
 
 ## Config Parameters
 

--- a/runner.py
+++ b/runner.py
@@ -1,3 +1,4 @@
+from distutils.util import strtobool
 import numpy as np
 import argparse, copy, os, yaml
 import ray, signal
@@ -15,6 +16,12 @@ if __name__ == '__main__':
     ap.add_argument("-na", "--num_actors", type=int, default=0, required=False, 
                     help="number of envs running in parallel, if larger than 0 will overwrite the value in yaml config")
     ap.add_argument("-s", "--sigma", type=float, required=False, help="sets new sigma value in case if 'fixed_sigma: True' in yaml config")
+    ap.add_argument("--track", type=lambda x: bool(strtobool(x)), default=False, nargs="?", const=True,
+        help="if toggled, this experiment will be tracked with Weights and Biases")
+    ap.add_argument("--wandb-project-name", type=str, default="rl_games",
+        help="the wandb's project name")
+    ap.add_argument("--wandb-entity", type=str, default=None,
+        help="the entity (team) of wandb's project")
     os.makedirs("nn", exist_ok=True)
     os.makedirs("runs", exist_ok=True)
 
@@ -38,6 +45,18 @@ if __name__ == '__main__':
             runner.load(config)
         except yaml.YAMLError as exc:
             print(exc)
+
+    if args["track"]:
+        import wandb
+
+        wandb.init(
+            project=args["wandb_project_name"],
+            entity=args["wandb_entity"],
+            sync_tensorboard=True,
+            config=config,
+            monitor_gym=True,
+            save_code=True,
+        )
 
     runner.run(args)
 


### PR DESCRIPTION
Feel free to run 

```
python runner.py --train --file rl_games/configs/atari/ppo_breakout_torch.yaml --track
WANDB_API_KEY=xxxx python runner.py --train --file rl_games/configs/atari/ppo_breakout_torch.yaml --track
python runner.py --train --file rl_games/configs/atari/ppo_breakout_torch.yaml --wandb-project-name rl-games-special-test --track
python runner.py --train --file rl_games/configs/atari/ppo_breakout_torch.yaml --wandb-project-name rl-games-special-test -wandb-entity openrlbenchmark --track
```