### PR TITLE
Fixed https://github.com/Denys88/rl_games/issues/148

### DIFF
--- a/rl_games/common/a2c_common.py
+++ b/rl_games/common/a2c_common.py
@@ -1223,7 +1223,7 @@ class ContinuousA2CBase(A2CBase):
                                 should_exit = True
 
                 if epoch_num >= self.max_epochs:
-                    self.save(os.path.join(self.nn_dir, 'last_' + self.config['name'] + 'ep' + str(epoch_num) + 'rew' + str(mean_rewards)))
+                    self.save(os.path.join(self.nn_dir, 'last_' + self.config['name'] + 'ep' + str(epoch_num) + 'rew' + str(self.game_rewards.get_mean())))
                     print('MAX EPOCHS NUM!')
                     should_exit = True
 

--- a/rl_games/common/a2c_common.py
+++ b/rl_games/common/a2c_common.py
@@ -975,9 +975,15 @@ class DiscreteA2CBase(A2CBase):
                                 should_exit = True
 
                 if epoch_num >= self.max_epochs:
-                    self.save(os.path.join(self.nn_dir, 'last_' + checkpoint_name))
+                    if self.game_rewards.current_size == 0:
+                        print('WARNING: Max epochs reached before any env terminated at least once')
+                        mean_rewards = -np.inf
+
+                    self.save(os.path.join(self.nn_dir,
+                                               'last_' + self.config['name'] + 'ep' + str(epoch_num) + 'rew' + str(
+                                                   mean_rewards)))
                     print('MAX EPOCHS NUM!')
-                    should_exit = True                         
+                    should_exit = True
                 update_time = 0
 
             if self.multi_gpu:
@@ -1223,7 +1229,10 @@ class ContinuousA2CBase(A2CBase):
                                 should_exit = True
 
                 if epoch_num >= self.max_epochs:
-                    self.save(os.path.join(self.nn_dir, 'last_' + self.config['name'] + 'ep' + str(epoch_num) + 'rew' + str(self.game_rewards.get_mean())))
+                    if self.game_rewards.current_size == 0:
+                        print('WARNING: Max epochs reached before any env terminated at least once')
+                        mean_rewards = -np.inf
+                    self.save(os.path.join(self.nn_dir, 'last_' + self.config['name'] + 'ep' + str(epoch_num) + 'rew' + str(mean_rewards)))
                     print('MAX EPOCHS NUM!')
                     should_exit = True
 


### PR DESCRIPTION
Fixed https://github.com/Denys88/rl_games/issues/148
If max_epochs reached earlier than any env terminates it crashes because of the mean_reward.
In most cases it happens only when there is a bug in environment and it never sends done=True.