### PR TITLE
BasePlayer modification

### DIFF
--- a/rl_games/common/player.py
+++ b/rl_games/common/player.py
@@ -22,11 +22,10 @@ class BasePlayer(object):
         if self.env_info is None:
             self.env = vecenv.create_vec_env(self.env_name, self.config['num_actors'], **self.env_config)
             self.env_info = self.env.get_env_info()
-            self.num_agents = 1
         else:
-            # is there any way 'self.env' can be used in this scenario?
-            # self.env = config.get('vec_env')
-            self.num_agents = self.env_info['agents']
+            self.env = config.get('vec_env')
+        
+        self.num_agents = self.env_info.get('agents', 1)
         self.value_size = self.env_info.get('value_size', 1)
         self.action_space = self.env_info['action_space']
 

--- a/rl_games/common/player.py
+++ b/rl_games/common/player.py
@@ -3,26 +3,32 @@ import gym
 import numpy as np
 import torch
 import copy
+from rl_games.common import vecenv
 from rl_games.common import env_configurations
-from rl_games.algos_torch import  model_builder
+from rl_games.algos_torch import model_builder
+
 
 class BasePlayer(object):
     def __init__(self, params):
         self.config = config = params['config']
         self.load_networks(params)
         self.env_name = self.config['env_name']
+        self.player_config = self.config.get('player', {})
         self.env_config = self.config.get('env_config', {})
+        self.env_config = self.player_config.get('env_config', self.env_config)
         self.env_info = self.config.get('env_info')
         self.clip_actions = config.get('clip_actions', True)
         self.seed = self.env_config.pop('seed', None)
         if self.env_info is None:
-            self.env = self.create_env()
-            self.env_info = env_configurations.get_env_info(self.env)
+            self.env = vecenv.create_vec_env(self.env_name, self.config['num_actors'], **self.env_config)
+            self.env_info = self.env.get_env_info()
+            self.num_agents = 1
         else:
-            self.env = config.get('vec_env')
+            # is there any way 'self.env' can be used in this scenario?
+            # self.env = config.get('vec_env')
+            self.num_agents = self.env_info['agents']
         self.value_size = self.env_info.get('value_size', 1)
         self.action_space = self.env_info['action_space']
-        self.num_agents = self.env_info['agents']
 
         self.observation_space = self.env_info['observation_space']
         if isinstance(self.observation_space, gym.spaces.Dict):


### PR DESCRIPTION
- Player configuration override 

Example:
```
config:
  env_config:
     ... train parameters ... 
  player:
      env_config:
         ... play parameters ... 

```

- Vectorized environment configuration ([Original PR / no activity](https://github.com/Denys88/rl_games/pull/135))

Test plan:

1. Train models for two different scenarios 
python runner.py --train --file rl_games/configs/brax/ppo_ant.yaml 
python runner.py --train --file rl_games/configs/ppo_cartpole.yaml

2. Run model with & without proposed change. (No crash, similar results)
3. Benchmark change (brax/ant)


| Time | Before | After |
| ------------- |  ------------- | ------------- |
| real | 1m32.151s  | 0m42.622s |
| user | 1m21.269s | 0m49.443s |
| sys | 0m31.144s | 0m17.270s |