### PR TITLE
Multi-node training support

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ Additional environment supported properties and functions
 * New methods didn't. It is impossible to turn it on from the yaml files. Once we find an env which trains better it will be added to the config.
 * Added shaped reward graph to the tensorboard.
 * Fixed bug with SAC not saving weights with save_frequency.
-* Added multi-node training support for GPU-accelerated training environments like Isaac Gym. Thanks to @ankurhanda and @ArthurAllshire for assistance.
+* Added multi-node training support for GPU-accelerated training environments like Isaac Gym. No changes in training scripts are required. Thanks to @ankurhanda and @ArthurAllshire for assistance.
 
 1.6.0
 

--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ Additional environment supported properties and functions
 * New methods didn't. It is impossible to turn it on from the yaml files. Once we find an env which trains better it will be added to the config.
 * Added shaped reward graph to the tensorboard.
 * Fixed bug with SAC not saving weights with save_frequency.
-* Added multi-node training support for GPU-accelerated training environments like Isaac Gym.
+* Added multi-node training support for GPU-accelerated training environments like Isaac Gym. Thanks to @ankurhanda and @ArthurAllshire for thoughtful comments.
 
 
 1.6.0

--- a/README.md
+++ b/README.md
@@ -292,7 +292,9 @@ Additional environment supported properties and functions
 * Added Deepmind Control PPO benchmark.
 * Added a few more experimental ways to train value prediction (OneHot, TwoHot encoding and crossentropy loss instead of L2).
 * New methods didn't. It is impossible to turn it on from the yaml files. Once we find an env which trains better it will be added to the config.
-* Added shaped reward graph to the tensorboard. 
+* Added shaped reward graph to the tensorboard.
+* Fixed bug with SAC not saving weights with save_frequency.
+* Added multi-node training support for GPU-accelerated training environments like Isaac Gym.
 
 
 1.6.0

--- a/README.md
+++ b/README.md
@@ -294,8 +294,7 @@ Additional environment supported properties and functions
 * New methods didn't. It is impossible to turn it on from the yaml files. Once we find an env which trains better it will be added to the config.
 * Added shaped reward graph to the tensorboard.
 * Fixed bug with SAC not saving weights with save_frequency.
-* Added multi-node training support for GPU-accelerated training environments like Isaac Gym. Thanks to @ankurhanda and @ArthurAllshire for thoughtful comments.
-
+* Added multi-node training support for GPU-accelerated training environments like Isaac Gym. Thanks to @ankurhanda and @ArthurAllshire assistance.
 
 1.6.0
 

--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ Additional environment supported properties and functions
 * New methods didn't. It is impossible to turn it on from the yaml files. Once we find an env which trains better it will be added to the config.
 * Added shaped reward graph to the tensorboard.
 * Fixed bug with SAC not saving weights with save_frequency.
-* Added multi-node training support for GPU-accelerated training environments like Isaac Gym. Thanks to @ankurhanda and @ArthurAllshire assistance.
+* Added multi-node training support for GPU-accelerated training environments like Isaac Gym. Thanks to @ankurhanda and @ArthurAllshire for assistance.
 
 1.6.0
 

--- a/rl_games/algos_torch/central_value.py
+++ b/rl_games/algos_torch/central_value.py
@@ -278,7 +278,7 @@ class CentralValueTrain(nn.Module):
             for param in self.model.parameters():
                 if param.grad is not None:
                     param.grad.data.copy_(
-                        all_grads[offset : offset + param.numel()].view_as(param.grad.data) / self.rank_size
+                        all_grads[offset : offset + param.numel()].view_as(param.grad.data) / self.world_size
                     )
                     offset += param.numel()
 

--- a/rl_games/algos_torch/central_value.py
+++ b/rl_games/algos_torch/central_value.py
@@ -73,6 +73,7 @@ class CentralValueTrain(nn.Module):
         self.is_rnn = self.model.is_rnn()
         self.rnn_states = None
         self.batch_size = self.horizon_length * self.num_actors
+
         if self.is_rnn:
             self.rnn_states = self.model.get_default_rnn_state()
             self.rnn_states = [s.to(self.ppo_device) for s in self.rnn_states]
@@ -85,10 +86,6 @@ class CentralValueTrain(nn.Module):
         self.global_rank = 0
         self.world_size = 1
         if self.multi_gpu:
-            # self.rank = int(os.getenv("LOCAL_RANK", "0"))
-            # self.rank_size = int(os.getenv("WORLD_SIZE", "1"))
-            # dist.init_process_group("nccl", rank=self.rank, world_size=self.rank_size)
-
             # local rank of the GPU in a node
             self.local_rank = int(os.getenv("LOCAL_RANK", "0"))
             # global rank of the GPU
@@ -98,6 +95,7 @@ class CentralValueTrain(nn.Module):
 
             self.device_name = 'cuda:' + str(self.local_rank)
             config['device'] = self.device_name
+
             if self.global_rank != 0:
                 config['print_stats'] = False
                 config['lr_schedule'] = None

--- a/rl_games/algos_torch/network_builder.py
+++ b/rl_games/algos_torch/network_builder.py
@@ -651,7 +651,8 @@ class A2CResnetBuilder(NetworkBuilder):
 
             self.value = self._build_value_layer(out_size, self.value_size)
             self.value_act = self.activations_factory.create(self.value_activation)
-            self.flatten_act = self.activations_factory.create(self.activation) 
+            self.flatten_act = self.activations_factory.create(self.activation)
+
             if self.is_discrete:
                 self.logits = torch.nn.Linear(out_size, actions_num)
             if self.is_continuous:

--- a/rl_games/common/player.py
+++ b/rl_games/common/player.py
@@ -20,6 +20,7 @@ class BasePlayer(object):
         self.env_info = self.config.get('env_info')
         self.clip_actions = config.get('clip_actions', True)
         self.seed = self.env_config.pop('seed', None)
+
         if self.env_info is None:
             use_vecenv = self.player_config.get('use_vecenv', False)
             if use_vecenv:
@@ -57,11 +58,13 @@ class BasePlayer(object):
         self.device_name = self.config.get('device_name', 'cuda')
         self.render_env = self.player_config.get('render', False)
         self.games_num = self.player_config.get('games_num', 2000)
+
         if 'deterministic' in self.player_config:
             self.is_deterministic = self.player_config['deterministic']
         else:
             self.is_deterministic = self.player_config.get(
                 'deterministic', True)
+
         self.n_game_life = self.player_config.get('n_game_life', 1)
         self.print_stats = self.player_config.get('print_stats', True)
         self.render_sleep = self.player_config.get('render_sleep', 0.002)

--- a/rl_games/envs/diambra/diambra.py
+++ b/rl_games/envs/diambra/diambra.py
@@ -5,7 +5,9 @@ import random
 from diambra_environment.diambraGym import diambraGym
 from diambra_environment.makeDiambraEnv import make_diambra_env
 
+
 class DiambraEnv(gym.Env):
+
     def __init__(self, **kwargs):
         gym.Env.__init__(self)
         self.seed = kwargs.pop('seed', None)
@@ -17,7 +19,7 @@ class DiambraEnv(gym.Env):
         self.attacks_buttons = kwargs.pop('attacks_buttons', False)
         self._game_num = 0
         self.n_agents = 1
-        self.rank = random.randint(0, 100500)
+        self.random_seed = random.randint(0, 100500)
         repo_base_path = os.path.abspath(self.env_path) # Absolute path to your DIAMBRA environment
 
         env_kwargs = {}
@@ -61,7 +63,7 @@ class DiambraEnv(gym.Env):
         key_to_add.append("stage")
         key_to_add.append("character")
         
-        self.env = make_diambra_env(diambraGym, env_prefix="Train" + str(self.rank), seed= self.rank,  
+        self.env = make_diambra_env(diambraGym, env_prefix="Train" + str(self.random_seed), seed=self.random_seed,  
             diambra_kwargs=env_kwargs, 
             diambra_gym_kwargs=gym_kwargs,
             wrapper_kwargs=wrapper_kwargs, 
@@ -69,7 +71,6 @@ class DiambraEnv(gym.Env):
 
         self.observation_space = self.env.observation_space
         self.action_space = self.env.action_space
-
 
     def _preproc_state_obs(self, obs):
         return obs

--- a/rl_games/torch_runner.py
+++ b/rl_games/torch_runner.py
@@ -78,11 +78,6 @@ class Runner:
 
             print(f"global_rank = {self.global_rank} local_rank = {self.local_rank} world_size = {self.world_size}")
 
-            #assert self.device == 'cuda:' + str(self.multi_gpu_rank) # check it was set correctly
-            #self.is_master_gpu = self.multi_gpu_rank == 0
-            #assert self.device == 'cuda:' + str(self.multi_gpu_local_rank) # check it was set correctly
-
-            #self.seed += int(os.getenv("LOCAL_RANK", "0"))
         print(f"self.seed = {self.seed}")
 
         self.algo_params = params['algo']

--- a/runner.py
+++ b/runner.py
@@ -1,11 +1,9 @@
 from distutils.util import strtobool
-import numpy as np
-import argparse, copy, os, yaml
+import argparse, os, yaml
 import ray
 
 os.environ["XLA_PYTHON_CLIENT_PREALLOCATE"] = "false"
-#import warnings
-#warnings.filterwarnings("error")
+
 
 if __name__ == '__main__':
     ap = argparse.ArgumentParser()
@@ -52,8 +50,9 @@ if __name__ == '__main__':
         except yaml.YAMLError as exc:
             print(exc)
 
-    rank = int(os.getenv("LOCAL_RANK", "0"))
-    if args["track"] and rank == 0:
+    #rank = int(os.getenv("LOCAL_RANK", "0"))
+    global_rank = int(os.getenv("RANK", "0"))
+    if args["track"] and global_rank == 0:
         import wandb
 
         wandb.init(
@@ -69,5 +68,5 @@ if __name__ == '__main__':
 
     ray.shutdown()
 
-    if args["track"] and rank == 0:
+    if args["track"] and global_rank == 0:
         wandb.finish()

--- a/setup.py
+++ b/setup.py
@@ -39,13 +39,12 @@ setup(name='rl-games',
             'gym>=0.17.2',
             'torch>=1.7.0',
             'numpy>=1.16.0',
-            'ray>=1.1.0',
+            # to support Python 3.10
+            'ray>=2.2.0',
             'tensorboard>=1.14.0',
             'tensorboardX>=1.6',
             'setproctitle',
             'psutil',
             'pyyaml'
-            # Optional dependencies
-            # 'ray>=1.1.0',
       ],
       )


### PR DESCRIPTION
Random seeds and statistics are now handled correctly for multi-node training cases. No changes to training scripts are required. Multi-gpu/multi-node training is currently supported only for GPU-accelerated simulators like Isaac Gym.