### PR TITLE
fixed bug with multi-gpu training for continuous a2c in a2c_common.py

### DIFF
--- a/rl_games/common/a2c_common.py
+++ b/rl_games/common/a2c_common.py
@@ -1308,6 +1308,7 @@ class ContinuousA2CBase(A2CBase):
         self.curr_frames = self.batch_size_envs
 
         if self.multi_gpu:
+            torch.cuda.set_device(self.local_rank)
             print("====================broadcasting parameters")
             model_params = [self.model.state_dict()]
             dist.broadcast_object_list(model_params, 0)


### PR DESCRIPTION
Fixed bug with missed torch.cuda.set_device(self.local_rank), which causes a problem when two different parallel processes try to use the same GPU in multi-gpu training with continuous a2c implementation