### PR TITLE
Fix SAC with input normalization

### DIFF
--- a/rl_games/algos_torch/players.py
+++ b/rl_games/algos_torch/players.py
@@ -199,7 +199,7 @@ class SACPlayer(BasePlayer):
         ]
 
         obs_shape = self.obs_shape
-        self.normalize_input = False
+        self.normalize_input = self.config.get('normalize_input', False)
         config = {
             'obs_dim': self.env_info["observation_space"].shape[0],
             'action_dim': self.env_info["action_space"].shape[0],
@@ -229,6 +229,7 @@ class SACPlayer(BasePlayer):
     def get_action(self, obs, is_deterministic=False):
         if self.has_batch_dimension == False:
             obs = unsqueeze_obs(obs)
+        obs = self.model.norm_obs(obs)
         dist = self.model.actor(obs)
         actions = dist.sample() if is_deterministic else dist.mean
         actions = actions.clamp(*self.action_range).to(self.device)

--- a/rl_games/algos_torch/sac_agent.py
+++ b/rl_games/algos_torch/sac_agent.py
@@ -208,6 +208,8 @@ class SACAgent(BaseAlgorithm):
         state = {'actor': self.model.sac_network.actor.state_dict(),
          'critic': self.model.sac_network.critic.state_dict(), 
          'critic_target': self.model.sac_network.critic_target.state_dict()}
+        if self.normalize_input:
+            state['running_mean_std'] = self.model.running_mean_std.state_dict()
         return state
 
     def save(self, fn):


### PR DESCRIPTION
Atm, SAC does not work when giving normalize_input in the config.yml
I propose an easy fix:

1. In sac_agent.py, check if the self.normalize_input attribute is set. If yes, include the weights of the running_mean_std in the stat in get_weights method

2. In players.py, get self.normalize_input from the config and apply self.model.norm_obs to the observation in get_action
If normalize_input is False, then self.model.norm_obs will just be the Identity. If it is True, then it will apply the running mean to the observation 