### PR TITLE
Ensure the consistency of central_value_net with the same initial parameters before training starts in a multi-GPU setting.

### DIFF
--- a/rl_games/common/a2c_common.py
+++ b/rl_games/common/a2c_common.py
@@ -1044,8 +1044,12 @@ class DiscreteA2CBase(A2CBase):
             torch.cuda.set_device(self.local_rank)
             print("====================broadcasting parameters")
             model_params = [self.model.state_dict()]
+            if self.has_central_value:
+                model_params.append(self.central_value_net.state_dict())
             dist.broadcast_object_list(model_params, 0)
             self.model.load_state_dict(model_params[0])
+            if self.has_central_value:
+                self.central_value_net.load_state_dict(model_params[1])
 
         while True:
             epoch_num = self.update_epoch()
@@ -1320,8 +1324,12 @@ class ContinuousA2CBase(A2CBase):
             torch.cuda.set_device(self.local_rank)
             print("====================broadcasting parameters")
             model_params = [self.model.state_dict()]
+            if self.has_central_value:
+                model_params.append(self.central_value_net.state_dict())
             dist.broadcast_object_list(model_params, 0)
             self.model.load_state_dict(model_params[0])
+            if self.has_central_value:
+                self.central_value_net.load_state_dict(model_params[1])
 
         while True:
             epoch_num = self.update_epoch()


### PR DESCRIPTION
Solution for Potential Issues with Multi-GPU/Node Training with Central Network Weights Initialization [#296](https://github.com/Denys88/rl_games/issues/296)