### PR TITLE
Added a few features to make rl_games more comparable to the brax with jax ppo

### DIFF
--- a/rl_games/algos_torch/model_builder.py
+++ b/rl_games/algos_torch/model_builder.py
@@ -46,6 +46,8 @@ class ModelBuilder:
                                             lambda network, **kwargs: models.ModelSACContinuous(network))
         self.model_factory.register_builder('central_value',
                                             lambda network, **kwargs: models.ModelCentralValue(network))
+        self.model_factory.register_builder('continuous_a2c_tanh',
+                                            lambda network, **kwargs: models.ModelA2CContinuousTanh(network))
         self.network_builder = NetworkBuilder()
 
     def get_network_builder(self):

--- a/rl_games/common/a2c_common.py
+++ b/rl_games/common/a2c_common.py
@@ -947,6 +947,7 @@ class DiscreteA2CBase(A2CBase):
 
         for mini_ep in range(0, self.mini_epochs_num):
             ep_kls = []
+            self.dataset.apply_permutation()
             for i in range(len(self.dataset)):
                 a_loss, c_loss, entropy, kl, last_lr, lr_mul = self.train_actor_critic(self.dataset[i])
                 a_losses.append(a_loss)

--- a/rl_games/common/datasets.py
+++ b/rl_games/common/datasets.py
@@ -22,13 +22,12 @@ class PPODataset(Dataset):
         self.length = self.batch_size // self.minibatch_size
         self.is_discrete = is_discrete
         self.is_continuous = not is_discrete
-        total_games = self.batch_size // self.seq_length
         self.num_games_batch = self.minibatch_size // self.seq_length
-        self.game_indexes = torch.arange(total_games, dtype=torch.long, device=self.device)
-        self.flat_indexes = torch.arange(total_games * self.seq_length, dtype=torch.long, device=self.device).reshape(total_games, self.seq_length)
+        
         self.special_names = ['rnn_states']
         self.permute = permute
-        self.permutation_indices = torch.arange(self.batch_size, dtype=torch.long, device=self.device)
+        if self.permute:
+            self.permutation_indices = torch.arange(self.batch_size, dtype=torch.long, device=self.device)
 
     def update_values_dict(self, values_dict):
         """Update the internal values dictionary."""

--- a/rl_games/common/datasets.py
+++ b/rl_games/common/datasets.py
@@ -3,9 +3,16 @@ import copy
 from torch.utils.data import Dataset
 
 
-class PPODataset(Dataset):
+import torch
+from torch.utils.data import Dataset
+import random
 
-    def __init__(self, batch_size, minibatch_size, is_discrete, is_rnn, device, seq_length):
+class PPODataset(Dataset):
+    def __init__(self, batch_size, minibatch_size, is_discrete, is_rnn, device, seq_length, permute=False):
+        if batch_size % minibatch_size != 0:
+            raise ValueError("Batch size must be divisible by minibatch size.")
+        if batch_size % seq_length != 0:
+            raise ValueError("Batch size must be divisible by sequence length.")
 
         self.is_rnn = is_rnn
         self.seq_length = seq_length
@@ -19,66 +26,73 @@ class PPODataset(Dataset):
         self.num_games_batch = self.minibatch_size // self.seq_length
         self.game_indexes = torch.arange(total_games, dtype=torch.long, device=self.device)
         self.flat_indexes = torch.arange(total_games * self.seq_length, dtype=torch.long, device=self.device).reshape(total_games, self.seq_length)
-
         self.special_names = ['rnn_states']
+        self.permute = permute
+        self.permutation_indices = torch.arange(self.batch_size, dtype=torch.long, device=self.device)
 
     def update_values_dict(self, values_dict):
-        self.values_dict = values_dict     
+        """Update the internal values dictionary."""
+        self.values_dict = values_dict
 
-    def update_mu_sigma(self, mu, sigma):	    
-        start = self.last_range[0]	           
-        end = self.last_range[1]	
-        self.values_dict['mu'][start:end] = mu	
-        self.values_dict['sigma'][start:end] = sigma 
+    def update_mu_sigma(self, mu, sigma):
+        """Update the mu and sigma values in the dataset."""
+        start, end = self.last_range
+        # Ensure the permutation does not break the logic for updating.
+        #if self.permute:
+        #    original_indices = self.permutation_indices[start:end]
+        #    self.values_dict['mu'][original_indices] = mu
+        #    self.values_dict['sigma'][original_indices] = sigma
+        #else:
+        self.values_dict['mu'][start:end] = mu
+        self.values_dict['sigma'][start:end] = sigma
 
-    def __len__(self):
-        return self.length
+    def apply_permutation(self):
+        """Permute the dataset indices if the permutation flag is enabled."""
+        if self.permute and not self.is_rnn:
+            self.permutation_indices = torch.randperm(self.batch_size, device=self.device, dtype=torch.long)
+            for key, value in self.values_dict.items():
+                if key not in self.special_names and value is not None:
+                    if isinstance(value, dict):
+                        for k, v in value.items():
+                            self.values_dict[key][k] = v[self.permutation_indices]
+                    else:
+                        self.values_dict[key] = value[self.permutation_indices]
+
+    def _slice_data(self, data, start, end):
+        """Slice data from start to end, handling dictionaries."""
+        if isinstance(data, dict):
+            return {k: v[start:end] for k, v in data.items()}
+        return data[start:end] if data is not None else None
 
     def _get_item_rnn(self, idx):
+        """Retrieve a batch of data for RNN training."""
         gstart = idx * self.num_games_batch
         gend = (idx + 1) * self.num_games_batch
         start = gstart * self.seq_length
         end = gend * self.seq_length
         self.last_range = (start, end)
 
-        input_dict = {}
-        for k,v in self.values_dict.items():
-            if k not in self.special_names:
-                if isinstance(v, dict):
-                    v_dict = {kd:vd[start:end] for kd, vd in v.items()}
-                    input_dict[k] = v_dict
-                else:
-                    if v is not None:
-                        input_dict[k] = v[start:end]
-                    else:
-                        input_dict[k] = None
-        
-        rnn_states = self.values_dict['rnn_states']
-        input_dict['rnn_states'] = [s[:, gstart:gend, :].contiguous() for s in rnn_states]
-
+        input_dict = {k: self._slice_data(v, start, end) for k, v in self.values_dict.items() if k not in self.special_names}
+        input_dict['rnn_states'] = [s[:, gstart:gend, :].contiguous() for s in self.values_dict['rnn_states']]
         return input_dict
 
     def _get_item(self, idx):
+        """Retrieve a minibatch of data."""
         start = idx * self.minibatch_size
         end = (idx + 1) * self.minibatch_size
         self.last_range = (start, end)
-        input_dict = {}
-        for k,v in self.values_dict.items():
-            if k not in self.special_names and v is not None:
-                if type(v) is dict:
-                    v_dict = { kd:vd[start:end] for kd, vd in v.items() }
-                    input_dict[k] = v_dict
-                else:
-                    input_dict[k] = v[start:end]
-                
+
+        input_dict = {k: self._slice_data(v, start, end) for k, v in self.values_dict.items() if k not in self.special_names and v is not None}
         return input_dict
 
     def __getitem__(self, idx):
-        if self.is_rnn:
-            sample = self._get_item_rnn(idx)
-        else:
-            sample = self._get_item(idx)
-        return sample
+        """Retrieve an item based on the dataset type (RNN or not)."""
+        return self._get_item_rnn(idx) if self.is_rnn else self._get_item(idx)
+
+    def __len__(self):
+        """Return the number of minibatches."""
+        return self.length
+
 
 
 

--- a/rl_games/common/player.py
+++ b/rl_games/common/player.py
@@ -25,7 +25,7 @@ class BasePlayer(object):
         self.env_info = self.config.get('env_info')
         self.clip_actions = config.get('clip_actions', True)
         self.seed = self.env_config.pop('seed', None)
-
+        self.balance_env_rewards  = self.player_config.get('balance_env_rewards', False)
         if self.env_info is None:
             use_vecenv = self.player_config.get('use_vecenv', False)
             if use_vecenv:
@@ -282,7 +282,6 @@ class BasePlayer(object):
         games_played = 0
         has_masks = False
         has_masks_func = getattr(self.env, "has_action_mask", None) is not None
-
         op_agent = getattr(self.env, "create_agent", None)
         if op_agent:
             agent_inited = True
@@ -311,6 +310,13 @@ class BasePlayer(object):
             cr = torch.zeros(batch_size, dtype=torch.float32)
             steps = torch.zeros(batch_size, dtype=torch.float32)
 
+            # Initialize per-environment accumulators if balance_env_rewards is enabled
+            if self.balance_env_rewards:
+                per_env_rewards = torch.zeros(batch_size, dtype=torch.float32)
+                per_env_steps = torch.zeros(batch_size, dtype=torch.float32)
+                per_env_game_res = torch.zeros(batch_size, dtype=torch.float32)
+                per_env_games_played = torch.zeros(batch_size, dtype=torch.float32)
+
             print_game_res = False
 
             for n in range(self.max_steps):
@@ -336,21 +342,12 @@ class BasePlayer(object):
                 done_indices = all_done_indices[::self.num_agents]
                 done_count = len(done_indices)
                 games_played += done_count
-
+                print(games_played)
                 if done_count > 0:
                     if self.is_rnn:
                         for s in self.states:
                             s[:, all_done_indices, :] = s[:,
-                                                          all_done_indices, :] * 0.0
-
-                    cur_rewards = cr[done_indices].sum().item()
-                    cur_steps = steps[done_indices].sum().item()
-
-                    cr = cr * (1.0 - done.float())
-                    steps = steps * (1.0 - done.float())
-                    sum_rewards += cur_rewards
-                    sum_steps += cur_steps
-
+                                                        all_done_indices, :] * 0.0
                     game_res = 0.0
                     if isinstance(info, dict):
                         if 'battle_won' in info:
@@ -360,25 +357,74 @@ class BasePlayer(object):
                             print_game_res = True
                             game_res = info.get('scores', 0.5)
 
-                    if self.print_stats:
-                        cur_rewards_done = cur_rewards/done_count
-                        cur_steps_done = cur_steps/done_count
+                    if self.balance_env_rewards:
+                        # Update per-environment accumulators
+                        per_env_rewards[done_indices] += cr[done_indices]
+                        per_env_steps[done_indices] += steps[done_indices]
+                        per_env_games_played[done_indices] += 1
                         if print_game_res:
-                            print(f'reward: {cur_rewards_done:.2f} steps: {cur_steps_done:.1f} w: {game_res}')
-                        else:
-                            print(f'reward: {cur_rewards_done:.2f} steps: {cur_steps_done:.1f}')
+                            per_env_game_res[done_indices] += game_res
 
-                    sum_game_res += game_res
-                    if batch_size//self.num_agents == 1 or games_played >= n_games:
+                        # Reset current rewards and steps for done environments
+                        cr[done_indices] = 0
+                        steps[done_indices] = 0
+                    else:
+                        # Original accumulation
+                        cur_rewards = cr[done_indices].sum().item()
+                        cur_steps = steps[done_indices].sum().item()
+
+                        cr = cr * (1.0 - done.float())
+                        steps = steps * (1.0 - done.float())
+                        sum_rewards += cur_rewards
+                        sum_steps += cur_steps
+                        sum_game_res += game_res
+
+                        if self.print_stats:
+                            cur_rewards_done = cur_rewards / done_count
+                            cur_steps_done = cur_steps / done_count
+                            if print_game_res:
+                                print(
+                                    f'reward: {cur_rewards_done:.2f} steps: {cur_steps_done:.1f} w: {game_res}')
+                            else:
+                                print(
+                                    f'reward: {cur_rewards_done:.2f} steps: {cur_steps_done:.1f}')
+
+                    if batch_size // self.num_agents == 1 or games_played >= n_games:
                         break
 
-        print(sum_rewards)
-        if print_game_res:
-            print('av reward:', sum_rewards / games_played * n_game_life, 'av steps:', sum_steps /
-                  games_played * n_game_life, 'winrate:', sum_game_res / games_played * n_game_life)
+        if self.balance_env_rewards:
+            # Calculate per-environment average rewards
+            valid_envs = per_env_games_played > 0
+            per_env_avg_rewards = torch.zeros(batch_size, dtype=torch.float32)
+            per_env_avg_steps = torch.zeros(batch_size, dtype=torch.float32)
+            per_env_avg_game_res = torch.zeros(batch_size, dtype=torch.float32)
+
+            per_env_avg_rewards[valid_envs] = (
+                per_env_rewards[valid_envs] / per_env_games_played[valid_envs])
+            per_env_avg_steps[valid_envs] = (
+                per_env_steps[valid_envs] / per_env_games_played[valid_envs])
+
+            overall_avg_reward = per_env_avg_rewards[valid_envs].mean().item()
+            overall_avg_steps = per_env_avg_steps[valid_envs].mean().item()
+
+            if print_game_res:
+                per_env_avg_game_res[valid_envs] = (
+                    per_env_game_res[valid_envs] / per_env_games_played[valid_envs])
+                overall_winrate = per_env_avg_game_res[valid_envs].mean().item()
+                print('av reward:', overall_avg_reward * n_game_life, 'av steps:', overall_avg_steps *
+                    n_game_life, 'winrate:', overall_winrate * n_game_life)
+            else:
+                print('av reward:', overall_avg_reward * n_game_life,
+                    'av steps:', overall_avg_steps * n_game_life)
         else:
-            print('av reward:', sum_rewards / games_played * n_game_life,
-                  'av steps:', sum_steps / games_played * n_game_life)
+            print(sum_rewards)
+            if print_game_res:
+                print('av reward:', sum_rewards / games_played * n_game_life, 'av steps:', sum_steps /
+                    games_played * n_game_life, 'winrate:', sum_game_res / games_played * n_game_life)
+            else:
+                print('av reward:', sum_rewards / games_played * n_game_life,
+                    'av steps:', sum_steps / games_played * n_game_life)
+
 
     def get_batch_size(self, obses, batch_size):
         obs_shape = self.obs_shape

--- a/rl_games/common/player.py
+++ b/rl_games/common/player.py
@@ -342,7 +342,6 @@ class BasePlayer(object):
                 done_indices = all_done_indices[::self.num_agents]
                 done_count = len(done_indices)
                 games_played += done_count
-                print(games_played)
                 if done_count > 0:
                     if self.is_rnn:
                         for s in self.states:

--- a/rl_games/envs/__init__.py
+++ b/rl_games/envs/__init__.py
@@ -1,7 +1,8 @@
 
 
-from rl_games.envs.test_network import TestNetBuilder, TestNetAuxLossBuilder
+from rl_games.envs.test_network import TestNetBuilder, TestNetAuxLossBuilder, SimpleNetBuilder
 from rl_games.algos_torch import model_builder
 
 model_builder.register_network('testnet', TestNetBuilder)
+model_builder.register_network('simplenet', SimpleNetBuilder)
 model_builder.register_network('testnet_aux_loss', TestNetAuxLossBuilder)


### PR DESCRIPTION
* Added Squashed tanh distribution. They use it in brax ppo. Didn't work great for me
* Added ability to return balanced results during evaluation. Unfortunately BRAX doesn't do resets with randomization.
* By default it just stores first observation and returns to it. It means if we have one env with borken start position where we always get done in a few step it overflows results. Need to use '**balance_env_rewards**' in evaluation to get the true scores.
* Added '**epochs_between_resets**' which is by default zero. Could be used with BRAX because they don't randomize position for envs during training in reset.
* It means that training rewards are much lower in rl-games than real one.
* Added one more example of the Simple Neural network called SimpleNet. If you use it you can get a little bit better performance. And overall it is a good example:
1) Works only for continuous.
2) [512, 256, 128] hardcoded layers single network for mu and val and independent layer for std.
3) torch.compile.
It didn't add a lot of perf in my case but nice to have.