### PR TITLE
Add custom stop callback for training (closes #348)

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,71 @@ Additional environment supported properties and functions
 
 
 
+## Custom stop callback
+
+In addition to the built-in `score_to_win`, `max_epochs`, and `max_frames` stop conditions, training can be terminated by a user-defined callback. The callback receives the algorithm instance and returns `True` to stop. It is checked once per epoch on rank 0 and broadcast to other ranks under multi-GPU. Works with PPO (continuous and discrete) and SAC.
+
+The signature:
+
+```python
+def my_stop(algo) -> bool:
+    # algo exposes: epoch_num, frame, last_mean_rewards, mean_rewards,
+    # game_rewards, game_lengths, config, ...
+    return algo.last_mean_rewards > 18.0 and algo.epoch_num >= 100
+```
+
+There are two ways to wire it in.
+
+### A. Manual algo instantiation
+
+Build the agent yourself, set the callback, then call `train()`:
+
+```python
+import yaml
+from rl_games.torch_runner import Runner
+
+with open('rl_games/configs/atari/ppo_pong.yaml') as f:
+    cfg = yaml.safe_load(f)
+
+runner = Runner()
+runner.load(cfg)
+runner.load_config(runner.default_config)
+
+agent = runner.algo_factory.create(
+    runner.algo_name, base_name='run', params=runner.params
+)
+agent.stop_fn = lambda algo: algo.last_mean_rewards > 18.0 and algo.epoch_num >= 100
+agent.train()
+```
+
+### B. Through `Runner.run`
+
+Pass the callable in the runtime args dict (programmatic), or reference it from YAML by import path (string).
+
+Programmatic:
+
+```python
+def my_stop(algo):
+    return algo.last_mean_rewards > 18.0 and algo.epoch_num >= 100
+
+runner = Runner()
+runner.load(cfg)
+runner.run({'train': True, 'stop_fn': my_stop})
+```
+
+YAML — set `config.stop_fn` to either `pkg.mod:function` or `pkg.mod.function`:
+
+```yaml
+params:
+  config:
+    stop_fn: my_project.stops:reward_plateau
+```
+
+The string is resolved by `importlib` at training start. `args['stop_fn']` (programmatic) takes precedence over `config['stop_fn']` (YAML) if both are set.
+
+`stop_fn` must be a callable taking the algo and returning `bool`; an `ValueError` is raised at startup otherwise.
+
+
 ## Troubleshouting
 
 * Some of the supported envs are not installed with setup.py, you need to manually install them

--- a/rl_games/algos_torch/sac_agent.py
+++ b/rl_games/algos_torch/sac_agent.py
@@ -168,6 +168,12 @@ class SACAgent(BaseAlgorithm):
         self.max_epochs = self.config.get('max_epochs', -1)
         self.max_frames = self.config.get('max_frames', -1)
 
+        # Optional user-supplied stop callback: callable(algo) -> bool.
+        # See README "Custom stop callback" section.
+        self.stop_fn = config.get('stop_fn', None)
+        if self.stop_fn is not None and not callable(self.stop_fn):
+            raise ValueError(f"'stop_fn' must be callable, got {type(self.stop_fn).__name__}")
+
         self.save_freq = config.get('save_frequency', 0)
 
         self.network = config['network']
@@ -725,6 +731,11 @@ class SACAgent(BaseAlgorithm):
                     self.save(os.path.join(self.nn_dir, 'last_' + self.config['name'] + '_frame_' + str(self.frame) \
                         + '_rew_' + str(mean_rewards).replace('[', '_').replace(']', '_')))
                     print('MAX FRAMES NUM!')
+                    should_exit = True
+
+                if not should_exit and self.stop_fn is not None and self.stop_fn(self):
+                    self.save(os.path.join(self.nn_dir, 'last_' + self.config['name'] + '_custom_stop_ep_' + str(self.epoch_num)))
+                    print('Custom stop callback returned True. Stopping training.')
                     should_exit = True
 
                 update_time = 0

--- a/rl_games/common/a2c_common.py
+++ b/rl_games/common/a2c_common.py
@@ -176,6 +176,13 @@ class A2CBase(BaseAlgorithm):
         self.max_epochs = self.config.get('max_epochs', -1)
         self.max_frames = np.max(self.config.get('max_frames', -1), self.config.get('max_steps', -1))
 
+        # Optional user-supplied stop callback: callable(algo) -> bool.
+        # Set programmatically (algo.stop_fn = ...) or via config['stop_fn'].
+        # See README "Custom stop callback" section.
+        self.stop_fn = config.get('stop_fn', None)
+        if self.stop_fn is not None and not callable(self.stop_fn):
+            raise ValueError(f"'stop_fn' must be callable, got {type(self.stop_fn).__name__}")
+
         self.is_adaptive_lr = config['lr_schedule'] == 'adaptive'
         self.linear_lr = config['lr_schedule'] == 'linear'
         self.schedule_type = config.get('schedule_type', 'legacy')
@@ -1173,6 +1180,11 @@ class DiscreteA2CBase(A2CBase):
                     print('MAX FRAMES NUM!')
                     should_exit = True
 
+                if not should_exit and self.stop_fn is not None and self.stop_fn(self):
+                    self.save(os.path.join(self.nn_dir, 'last_' + self.config['name'] + '_custom_stop_ep_' + str(epoch_num)))
+                    print('Custom stop callback returned True. Stopping training.')
+                    should_exit = True
+
                 update_time = 0
 
             if self.multi_gpu:
@@ -1454,6 +1466,11 @@ class ContinuousA2CBase(A2CBase):
                     self.save(os.path.join(self.nn_dir, 'last_' + self.config['name'] + '_frame_' + str(self.frame) \
                         + '_rew_' + str(mean_rewards).replace('[', '_').replace(']', '_')))
                     print('MAX FRAMES NUM!')
+                    should_exit = True
+
+                if not should_exit and self.stop_fn is not None and self.stop_fn(self):
+                    self.save(os.path.join(self.nn_dir, 'last_' + self.config['name'] + '_custom_stop_ep_' + str(epoch_num)))
+                    print('Custom stop callback returned True. Stopping training.')
                     should_exit = True
 
                 update_time = 0

--- a/rl_games/torch_runner.py
+++ b/rl_games/torch_runner.py
@@ -40,6 +40,41 @@ def _override_sigma(agent, args):
                 print('Cannot set new sigma because fixed_sigma is False')
 
 
+def _resolve_stop_fn(stop_fn):
+    """Accept either a callable or a 'pkg.mod:fn' / 'pkg.mod.fn' import path."""
+    if stop_fn is None or callable(stop_fn):
+        return stop_fn
+    if not isinstance(stop_fn, str):
+        raise ValueError(f"'stop_fn' must be callable or 'module:function' string, got {type(stop_fn).__name__}")
+    import importlib
+    if ':' in stop_fn:
+        module_path, attr = stop_fn.split(':', 1)
+    else:
+        module_path, _, attr = stop_fn.rpartition('.')
+        if not module_path:
+            raise ValueError(f"'stop_fn' string must reference a module attribute: {stop_fn!r}")
+    module = importlib.import_module(module_path)
+    fn = getattr(module, attr)
+    if not callable(fn):
+        raise ValueError(f"'stop_fn' resolved {stop_fn!r} is not callable")
+    return fn
+
+
+def _apply_stop_fn(params, args):
+    """Resolve stop_fn (callable or import-path string) and write it into params['config'].
+
+    Precedence: programmatic args['stop_fn'] > YAML config['stop_fn'].
+    Called before agent creation so the agent sees a callable, not a string.
+    """
+    stop_fn = args.get('stop_fn', None)
+    if stop_fn is None:
+        cfg = params.get('config', {}) or {}
+        stop_fn = cfg.get('stop_fn', None)
+    if stop_fn is None:
+        return
+    params.setdefault('config', {})['stop_fn'] = _resolve_stop_fn(stop_fn)
+
+
 class Runner:
     """Runs training/inference (playing) procedures as per a given configuration.
 
@@ -178,6 +213,8 @@ class Runner:
                 with_stack=True
             )
             profiler.__enter__()
+
+        _apply_stop_fn(self.params, args)
 
         agent = self.algo_factory.create(self.algo_name, base_name='run', params=self.params)
 


### PR DESCRIPTION
## Summary

- Adds an optional `stop_fn(algo) -> bool` callback that terminates training in addition to the existing `score_to_win` / `max_epochs` / `max_frames` conditions. Checked once per epoch on rank 0 and broadcast under multi-GPU.
- Wired into PPO (continuous and discrete) and SAC. Existing flows are unaffected when `stop_fn` is not set.
- README gains a "Custom stop callback" section documenting both wiring patterns.

Closes #348.

## Examples

### 1. YAML (string import path)

Reference any importable callable via `config.stop_fn`. The value can be either `pkg.mod:fn` or `pkg.mod.fn`; it is resolved with `importlib` at training start.

```python
# my_project/stops.py
def reward_plateau(algo):
    return algo.last_mean_rewards > 18.0 and algo.epoch_num >= 100
```

```yaml
# my_project/configs/ppo.yaml
params:
  config:
    name: my_run
    score_to_win: 1000000      # effectively disabled
    max_epochs: 10000
    stop_fn: my_project.stops:reward_plateau
```

Then run normally:

```bash
python -m rl_games.torch_runner --train --file my_project/configs/ppo.yaml
```

### 2. Manual callback (programmatic)

Set the callable directly on the agent — useful for closures, experiment harnesses, or notebook workflows.

```python
import yaml
from rl_games.torch_runner import Runner

with open('rl_games/configs/atari/ppo_pong.yaml') as f:
    cfg = yaml.safe_load(f)

runner = Runner()
runner.load(cfg)
runner.load_config(runner.default_config)

agent = runner.algo_factory.create(
    runner.algo_name, base_name='run', params=runner.params
)

# Stop once we've trained for at least 100 epochs and crossed a reward threshold.
agent.stop_fn = lambda algo: algo.last_mean_rewards > 18.0 and algo.epoch_num >= 100
agent.train()
```

Equivalent through `Runner.run` (callable passed at runtime, takes precedence over any YAML `stop_fn`):

```python
def my_stop(algo):
    return algo.last_mean_rewards > 18.0 and algo.epoch_num >= 100

runner = Runner()
runner.load(cfg)
runner.run({'train': True, 'stop_fn': my_stop})
```

When `stop_fn` returns `True`, a checkpoint named `last_<exp>_custom_stop_ep_<N>.pth` is written and training exits cleanly.

## Test plan

- [x] Train PPO (continuous, Pendulum) with a `stop_fn` returning `True` at `epoch_num>=2`; training stopped and `last_test_custom_stop_ep_2.pth` was written.
- [x] Train PPO (discrete, CartPole) with the same callback; same behavior — `last_cartpole_vel_info_custom_stop_ep_2.pth` written.
- [x] Train SAC (Pendulum) with a `stop_fn`; training stopped and `last_Pendulum_sac_custom_stop_ep_13.pth` written.
- [x] Verify YAML import-path form (`config.stop_fn: stop_fns:stop_at_epoch_2`) resolves and runs.
- [x] Verify `args['stop_fn']` takes precedence over YAML when both are set (YAML pointed at `stop_never`, args at `stop_at_2` → stopped at epoch 2).
- [x] Verify a non-callable `stop_fn` raises `ValueError` at startup (both bad-type and string-resolves-to-non-callable cases).
- [x] Verify a baseline run with no `stop_fn` is unaffected (3 epochs ran, exited via `MAX EPOCHS NUM!`, no `custom_stop` checkpoint).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
