### PR TITLE
Add optional capability_manifest passthrough to checkpoints (#352)

### DIFF
--- a/rl_games/algos_torch/sac_agent.py
+++ b/rl_games/algos_torch/sac_agent.py
@@ -19,6 +19,8 @@ class SACAgent(BaseAlgorithm):
     def __init__(self, base_name, params):
 
         self.config = config = params['config']
+        # Retain the full run params so an optional URML capability_manifest can travel with checkpoints.
+        self.params = params
         print(config)
 
         # TODO: Get obs shape and self.network
@@ -276,6 +278,9 @@ class SACAgent(BaseAlgorithm):
 
         if self.save_replay_buffer:
             state['replay_buffer'] = self.replay_buffer.state_dict()
+
+        # Optional URML capability manifest (no-op when absent), stored verbatim.
+        torch_ext.add_capability_manifest(state, self.params)
 
         return state
 

--- a/rl_games/algos_torch/torch_ext.py
+++ b/rl_games/algos_torch/torch_ext.py
@@ -87,6 +87,22 @@ def safe_load(filename):
         checkpoint = torch.load(filename, weights_only=False)
     return checkpoint
 
+def add_capability_manifest(state, params):
+    """Pass an optional URML capability manifest from the run params into a checkpoint, verbatim.
+
+    URML (https://urml.dev) declares the command ranges, terrain and payload
+    limits a policy was trained under. When the training params carry an
+    optional top-level ``capability_manifest`` block, this copies it into the
+    checkpoint state dict so the declaration travels with the policy. rl_games
+    takes no position on its schema: the block is stored verbatim, and this is
+    a no-op when absent. Consumers read ``checkpoint['capability_manifest']``.
+    """
+    manifest = (params or {}).get('capability_manifest')
+    if manifest is not None:
+        state['capability_manifest'] = manifest
+    return state
+
+
 def save_checkpoint(filename, state):
     print("=> saving checkpoint '{}'".format(filename + '.pth'))
     safe_save(state, filename + '.pth')

--- a/rl_games/common/a2c_common.py
+++ b/rl_games/common/a2c_common.py
@@ -69,6 +69,8 @@ class A2CBase(BaseAlgorithm):
     def __init__(self, base_name, params):
 
         self.config = config = params['config']
+        # Retain the full run params so an optional URML capability_manifest can travel with checkpoints.
+        self.params = params
         pbt_str = ''
         self.population_based_training = config.get('population_based_training', False)
         if self.population_based_training:
@@ -654,6 +656,9 @@ class A2CBase(BaseAlgorithm):
         if self.vec_env is not None:
             env_state = self.vec_env.get_env_state()
             state['env_state'] = env_state
+
+        # Optional URML capability manifest (no-op when absent), stored verbatim.
+        torch_ext.add_capability_manifest(state, self.params)
 
         return state
 

--- a/tests/test_capability_manifest.py
+++ b/tests/test_capability_manifest.py
@@ -1,0 +1,38 @@
+"""Tests for the optional URML capability_manifest checkpoint passthrough.
+
+rl_games stores an optional top-level ``capability_manifest`` block from the
+run params into the checkpoint verbatim, so a declaration of the limits a
+policy was trained under travels with the policy. rl_games takes no position
+on the manifest's schema.
+"""
+
+import pytest
+
+from rl_games.algos_torch import torch_ext
+
+
+def test_capability_manifest_passthrough_when_present():
+    manifest = {
+        "command_ranges": [{"quantity": "linear_velocity_x", "min": -0.5, "max": 1.0}],
+        "terrain_classes": ["rigid", "deformable"],
+    }
+    state = {"epoch": 3}
+    out = torch_ext.add_capability_manifest(state, {"capability_manifest": manifest, "config": {}})
+    assert out is state  # mutates and returns the same dict
+    assert state["capability_manifest"] == manifest  # stored verbatim
+
+
+def test_capability_manifest_absent_is_noop():
+    state = {"epoch": 3}
+    torch_ext.add_capability_manifest(state, {"config": {}})
+    assert "capability_manifest" not in state
+
+
+def test_capability_manifest_none_params_is_safe():
+    state = {"epoch": 3}
+    torch_ext.add_capability_manifest(state, None)
+    assert "capability_manifest" not in state
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])


### PR DESCRIPTION
## What

Adds an optional `capability_manifest:` passthrough, as offered in #352.

When the training params carry a top-level `capability_manifest:` block, rl_games copies it **verbatim** into the saved checkpoint dict (both the A2C/PPO path and SAC). rl_games takes no position on its schema; the block is stored as-is and is a no-op when absent. Consumers read `checkpoint['capability_manifest']`.

```yaml
params:
  capability_manifest:        # optional, opaque to rl_games
    command_ranges:
      - { quantity: linear_velocity_x, min: -0.5, max: 1.0, unit: m_per_s }
    terrain_classes: [rigid, deformable]
  algo: { name: a2c_continuous }
  config: { ... }
```

This lets the limits a policy was trained under travel **with** the policy, instead of being transcribed by hand downstream and drifting.

## Changes
- `torch_ext.add_capability_manifest(state, params)` — small, schema-agnostic helper (verbatim copy, no-op when absent).
- `A2CBase` and `SACAgent` retain `self.params` and call the helper in `get_full_state_weights()`.
- `tests/test_capability_manifest.py` — covers present / absent / `None`-params.

Net diff is +64 lines, no behavior change for existing runs (the block is opt-in).

## Context
This comes from [URML](https://urml.dev) (an open, Apache-2.0 language for robot intent). The motivating discussion is #352. Prose is AI-assisted and maintainer-reviewed per URML's [VIBE.md](https://github.com/URML-MARS/URML/blob/main/VIBE.md); happy to adjust naming, placement (top-level params vs `config:`), or anything else to fit your preferences.
