### PR TITLE
feat: optional capability_manifest passthrough in the checkpoint

### DIFF
--- a/rl_games/algos_torch/sac_agent.py
+++ b/rl_games/algos_torch/sac_agent.py
@@ -282,6 +282,14 @@ class SACAgent(BaseAlgorithm):
         if self.save_replay_buffer:
             state['replay_buffer'] = self.replay_buffer.state_dict()
 
+        # Optional capability_manifest passthrough. If the training config
+        # declares a `capability_manifest`, carry it verbatim with the
+        # checkpoint so it travels with the policy. rl_games takes no position
+        # on its schema; it is stored and restored opaquely.
+        capability_manifest = self.config.get('capability_manifest')
+        if capability_manifest is not None:
+            state['capability_manifest'] = capability_manifest
+
         return state
 
     def set_full_state_weights(self, weights, set_epoch=True):
@@ -306,6 +314,10 @@ class SACAgent(BaseAlgorithm):
         if self.vec_env is not None:
             env_state = weights.get('env_state', None)
             self.vec_env.set_env_state(env_state)
+
+        # Restore the optional capability_manifest passthrough (see get_full_state_weights).
+        if 'capability_manifest' in weights:
+            self.config['capability_manifest'] = weights['capability_manifest']
 
     def restore(self, fn, set_epoch=True):
         if not os.path.exists(fn):

--- a/rl_games/common/a2c_common.py
+++ b/rl_games/common/a2c_common.py
@@ -660,6 +660,14 @@ class A2CBase(BaseAlgorithm):
             env_state = self.vec_env.get_env_state()
             state['env_state'] = env_state
 
+        # Optional capability_manifest passthrough. If the training config
+        # declares a `capability_manifest`, carry it verbatim with the
+        # checkpoint so it travels with the policy. rl_games takes no position
+        # on its schema; it is stored and restored opaquely.
+        capability_manifest = self.config.get('capability_manifest')
+        if capability_manifest is not None:
+            state['capability_manifest'] = capability_manifest
+
         return state
 
     def set_full_state_weights(self, weights, set_epoch=True):
@@ -681,6 +689,10 @@ class A2CBase(BaseAlgorithm):
         if self.vec_env is not None:
             env_state = weights.get('env_state', None)
             self.vec_env.set_env_state(env_state)
+
+        # Restore the optional capability_manifest passthrough (see get_full_state_weights).
+        if 'capability_manifest' in weights:
+            self.config['capability_manifest'] = weights['capability_manifest']
 
     def set_central_value_function_weights(self, weights):
         self.central_value_net.load_state_dict(weights['assymetric_vf_nets'])

--- a/tests/test_capability_manifest_passthrough.py
+++ b/tests/test_capability_manifest_passthrough.py
@@ -1,0 +1,48 @@
+"""The optional `capability_manifest` config key is carried verbatim through a checkpoint.
+
+A training config may declare an opaque `capability_manifest:` block (for
+example, a robot-capability/intent manifest a downstream consumer reads to know
+the envelope a policy was trained under). rl_games takes no position on its
+schema; it must simply store the value verbatim in the checkpoint dict and
+restore it on load, so the manifest travels with the policy.
+"""
+import pytest
+
+from tests.test_critical_fixes import make_cartpole_agent
+
+MANIFEST = {
+    "manifest_version": "0.1",
+    "command_ranges": [{"quantity": "linear_velocity_x", "min": -1.5, "max": 1.5}],
+    "terrain_classes": ["rigid"],
+}
+
+
+def test_capability_manifest_saved_into_checkpoint():
+    agent = make_cartpole_agent(capability_manifest=MANIFEST)
+    state = agent.get_full_state_weights()
+    assert state.get("capability_manifest") == MANIFEST
+
+
+def test_capability_manifest_absent_when_not_declared():
+    agent = make_cartpole_agent()
+    state = agent.get_full_state_weights()
+    assert "capability_manifest" not in state
+
+
+def test_capability_manifest_roundtrips_on_restore():
+    src = make_cartpole_agent(capability_manifest=MANIFEST)
+    state = src.get_full_state_weights()
+
+    # A fresh agent with no capability_manifest in its own config picks it up
+    # from the checkpoint on restore.
+    dst = make_cartpole_agent()
+    assert "capability_manifest" not in dst.config
+    dst.set_full_state_weights(state)
+    assert dst.config["capability_manifest"] == MANIFEST
+
+
+def test_value_is_opaque_to_rl_games():
+    # rl_games takes no position on the schema: any opaque value rides along.
+    opaque = {"anything": [1, 2, 3], "nested": {"k": "v"}}
+    agent = make_cartpole_agent(capability_manifest=opaque)
+    assert agent.get_full_state_weights()["capability_manifest"] == opaque


### PR DESCRIPTION
Implements the optional `capability_manifest:` passthrough you offered in #352.

When a training config declares a `capability_manifest:` block, rl_games stores it verbatim in the checkpoint dict on save and restores it on load, for both the A2C/PPO agent (`a2c_common.py`) and the SAC agent (`sac_agent.py`). rl_games takes no position on the schema: the value is carried and restored opaquely, so a capability/intent manifest travels with the policy without rl_games depending on its format.

The change is small and additive, with no behavior change when the key is absent:

- `get_full_state_weights`: if `self.config.get('capability_manifest')` is set, add it to the checkpoint state.
- `set_full_state_weights`: if present in the checkpoint, restore it to `self.config`.

Tests live in `tests/test_capability_manifest_passthrough.py`, using the existing CPU CartPole harness: the value is saved when declared, absent when not, round-trips on restore, and is treated as opaque. The existing checkpoint round-trip tests still pass.

Thanks again for laying out the boundary so clearly and for the offer to take this.
