### PR TITLE
Fix Triton GAE kernel: NameError crash on triton <= 3.3 + hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,22 @@ We use `torchrun` to orchestrate any multi-gpu runs.
 torchrun --standalone --nnodes=1 --nproc_per_node=2 runner.py --train --file rl_games/configs/ppo_cartpole.yaml
 ```
 
+## Triton Kernels
+
+When [Triton](https://github.com/triton-lang/triton) is installed, rl_games automatically uses custom Triton kernels for performance-critical operations like GAE (Generalized Advantage Estimation). This replaces the Python for-loop with a single fused GPU kernel.
+
+Triton is enabled by default. To disable:
+
+```bash
+RLG_NO_TRITON=1 python runner.py --train --file rl_games/configs/mujoco/ant.yaml
+```
+
+Run the benchmark to see speedups on your hardware:
+
+```bash
+python benchmarks/bench_triton_gae.py
+```
+
 ## Config Parameters
 
 | Field                  | Example Value             | Default | Description                                                                                                                                                  |

--- a/rl_games/triton_config.py
+++ b/rl_games/triton_config.py
@@ -14,4 +14,4 @@ try:
 except ImportError:
     TRITON_AVAILABLE = False
 
-USE_TRITON = TRITON_AVAILABLE and not bool(int(os.environ.get('RLG_NO_TRITON', '0')))
+USE_TRITON = TRITON_AVAILABLE and os.environ.get('RLG_NO_TRITON', '0').strip().lower() not in ('1', 'true', 'yes', 'on')

--- a/rl_games/triton_kernels/gae_kernel.py
+++ b/rl_games/triton_kernels/gae_kernel.py
@@ -7,7 +7,56 @@ Disable Triton: export RLG_NO_TRITON=1
 """
 
 import torch
-from rl_games.triton_config import USE_TRITON
+from rl_games.triton_config import USE_TRITON, TRITON_AVAILABLE
+
+if TRITON_AVAILABLE:
+    import triton
+    import triton.language as tl
+
+    @triton.jit
+    def _gae_kernel(
+        rewards_ptr, values_ptr, dones_ptr,
+        last_values_ptr, last_dones_ptr, advs_ptr,
+        gamma, lam,
+        horizon: tl.constexpr,
+        value_size: tl.constexpr,
+        rewards_stride_t, rewards_stride_env,
+        values_stride_t, values_stride_env,
+        dones_stride_t, dones_stride_env,
+        advs_stride_t, advs_stride_env,
+    ):
+        pid = tl.program_id(0)
+        env_idx = pid // value_size
+        val_idx = pid % value_size
+
+        last_val = tl.load(last_values_ptr + env_idx * value_size + val_idx)
+        last_done = tl.load(last_dones_ptr + env_idx)
+        lastgaelam = 0.0
+
+        for t_fwd in range(horizon):
+            t = horizon - 1 - t_fwd
+
+            r_offset = t * rewards_stride_t + env_idx * rewards_stride_env + val_idx
+            v_offset = t * values_stride_t + env_idx * values_stride_env + val_idx
+            d_offset = t * dones_stride_t + env_idx * dones_stride_env
+
+            reward_t = tl.load(rewards_ptr + r_offset)
+            value_t = tl.load(values_ptr + v_offset)
+
+            if t == horizon - 1:
+                nextvalue = last_val
+                nextnonterminal = 1.0 - last_done
+            else:
+                next_v_offset = (t + 1) * values_stride_t + env_idx * values_stride_env + val_idx
+                next_d_offset = (t + 1) * dones_stride_t + env_idx * dones_stride_env
+                nextvalue = tl.load(values_ptr + next_v_offset)
+                nextnonterminal = 1.0 - tl.load(dones_ptr + next_d_offset)
+
+            delta = reward_t + gamma * nextvalue * nextnonterminal - value_t
+            lastgaelam = delta + gamma * lam * nextnonterminal * lastgaelam
+
+            adv_offset = t * advs_stride_t + env_idx * advs_stride_env + val_idx
+            tl.store(advs_ptr + adv_offset, lastgaelam)
 
 
 def _pytorch_gae(mb_rewards, mb_values, mb_dones, last_values, last_dones, gamma, tau):
@@ -31,7 +80,7 @@ def _pytorch_gae(mb_rewards, mb_values, mb_dones, last_values, last_dones, gamma
 
 
 def _triton_gae(mb_rewards, mb_values, mb_dones, last_values, last_dones, gamma, tau):
-    """GAE via Triton — single kernel launch, one program per env.
+    """GAE via Triton — single kernel launch, one program per (env, value) pair.
 
     Each Triton program scans backwards over the full horizon in-kernel,
     eliminating the per-timestep kernel launch overhead of the PyTorch loop.
@@ -43,66 +92,23 @@ def _triton_gae(mb_rewards, mb_values, mb_dones, last_values, last_dones, gamma,
         last_values: [num_envs, value_size]
         last_dones:  [num_envs]
     """
-    import triton
-    import triton.language as tl
-
-    @triton.jit
-    def _gae_kernel(
-        rewards_ptr, values_ptr, dones_ptr,
-        last_values_ptr, last_dones_ptr, advs_ptr,
-        gamma: tl.constexpr, lam: tl.constexpr,
-        horizon: tl.constexpr, num_envs: tl.constexpr,
-        value_size: tl.constexpr,
-        rewards_stride_t, rewards_stride_env,
-        values_stride_t, values_stride_env,
-        dones_stride_t, dones_stride_env,
-        advs_stride_t, advs_stride_env,
-    ):
-        pid = tl.program_id(0)
-        env_idx = pid // value_size
-        val_idx = pid % value_size
-
-        last_val = tl.load(last_values_ptr + env_idx * value_size + val_idx)
-        last_done = tl.load(last_dones_ptr + env_idx)
-        lastgaelam = 0.0
-
-        for t_fwd in range(horizon):
-            t = horizon - 1 - t_fwd
-
-            rv_offset = t * rewards_stride_t + env_idx * rewards_stride_env + val_idx
-            d_offset = t * dones_stride_t + env_idx * dones_stride_env
-
-            reward_t = tl.load(rewards_ptr + rv_offset)
-            value_t = tl.load(values_ptr + rv_offset)
-
-            if t == horizon - 1:
-                nextvalue = last_val
-                nextnonterminal = 1.0 - last_done
-            else:
-                next_rv_offset = (t + 1) * values_stride_t + env_idx * values_stride_env + val_idx
-                next_d_offset = (t + 1) * dones_stride_t + env_idx * dones_stride_env
-                nextvalue = tl.load(values_ptr + next_rv_offset)
-                nextnonterminal = 1.0 - tl.load(dones_ptr + next_d_offset)
-
-            delta = reward_t + gamma * nextvalue * nextnonterminal - value_t
-            lastgaelam = delta + gamma * lam * nextnonterminal * lastgaelam
-
-            adv_offset = t * advs_stride_t + env_idx * advs_stride_env + val_idx
-            tl.store(advs_ptr + adv_offset, lastgaelam)
-
     horizon_length, num_envs, value_size = mb_rewards.shape
-    mb_advs = torch.empty_like(mb_rewards)
 
-    if mb_dones.dtype != torch.float32:
-        mb_dones = mb_dones.float()
-    if last_dones.dtype != torch.float32:
-        last_dones = last_dones.float()
+    # The kernel assumes densely packed inputs (unit last-dim stride,
+    # flat last_values/last_dones indexing) — enforce it for view inputs.
+    mb_rewards = mb_rewards.contiguous()
+    mb_values = mb_values.contiguous()
+    mb_dones = mb_dones.float().contiguous()
+    last_values = last_values.contiguous()
+    last_dones = last_dones.float().contiguous()
+
+    mb_advs = torch.empty_like(mb_rewards)
 
     grid = (num_envs * value_size,)
 
     _gae_kernel[grid](
         mb_rewards, mb_values, mb_dones, last_values, last_dones, mb_advs,
-        gamma, tau, horizon_length, num_envs, value_size,
+        gamma, tau, horizon_length, value_size,
         mb_rewards.stride(0), mb_rewards.stride(1),
         mb_values.stride(0), mb_values.stride(1),
         mb_dones.stride(0), mb_dones.stride(1),
@@ -110,6 +116,9 @@ def _triton_gae(mb_rewards, mb_values, mb_dones, last_values, last_dones, gamma,
     )
 
     return mb_advs
+
+
+_backend_logged = False
 
 
 def compute_gae(mb_rewards, mb_values, mb_dones, last_values, last_dones, gamma, tau):
@@ -127,6 +136,11 @@ def compute_gae(mb_rewards, mb_values, mb_dones, last_values, last_dones, gamma,
     Returns:
         mb_advs: [horizon_length, num_envs, value_size]
     """
-    if USE_TRITON and mb_rewards.is_cuda:
+    use_triton = USE_TRITON and mb_rewards.is_cuda
+    global _backend_logged
+    if not _backend_logged:
+        print(f'compute_gae: using {"Triton" if use_triton else "PyTorch"} backend')
+        _backend_logged = True
+    if use_triton:
         return _triton_gae(mb_rewards, mb_values, mb_dones, last_values, last_dones, gamma, tau)
     return _pytorch_gae(mb_rewards, mb_values, mb_dones, last_values, last_dones, gamma, tau)

--- a/tests/test_triton_gae.py
+++ b/tests/test_triton_gae.py
@@ -1,0 +1,123 @@
+"""Correctness tests for the GAE implementations (PyTorch loop and Triton kernel).
+
+The Triton tests require CUDA and an importable triton; they are skipped
+otherwise (e.g. on CPU-only CI). The PyTorch-path tests always run.
+"""
+
+import os
+import subprocess
+import sys
+
+import pytest
+import torch
+
+from rl_games.triton_config import TRITON_AVAILABLE
+from rl_games.triton_kernels.gae_kernel import compute_gae, _pytorch_gae
+
+TRITON_CUDA = TRITON_AVAILABLE and torch.cuda.is_available()
+
+
+def reference_gae(mb_rewards, mb_values, mb_dones, last_values, last_dones, gamma, tau):
+    """Independent scalar reference: per-(env, value) backward recursion."""
+    horizon, num_envs, value_size = mb_rewards.shape
+    advs = torch.zeros_like(mb_rewards, dtype=torch.float64)
+    r = mb_rewards.double()
+    v = mb_values.double()
+    d = mb_dones.double()
+    lv = last_values.double()
+    ld = last_dones.double()
+    for e in range(num_envs):
+        for k in range(value_size):
+            lastgaelam = 0.0
+            for t in reversed(range(horizon)):
+                if t == horizon - 1:
+                    nextvalue = lv[e, k]
+                    nextnonterminal = 1.0 - ld[e]
+                else:
+                    nextvalue = v[t + 1, e, k]
+                    nextnonterminal = 1.0 - d[t + 1, e]
+                delta = r[t, e, k] + gamma * nextvalue * nextnonterminal - v[t, e, k]
+                lastgaelam = delta + gamma * tau * nextnonterminal * lastgaelam
+                advs[t, e, k] = lastgaelam
+    return advs.to(mb_rewards.dtype)
+
+
+def make_inputs(horizon, num_envs, value_size, device='cpu', seed=0):
+    g = torch.Generator().manual_seed(seed)
+    rewards = torch.randn(horizon, num_envs, value_size, generator=g)
+    values = torch.randn(horizon, num_envs, value_size, generator=g)
+    dones = (torch.rand(horizon, num_envs, generator=g) < 0.15).float()
+    last_values = torch.randn(num_envs, value_size, generator=g)
+    last_dones = (torch.rand(num_envs, generator=g) < 0.15).float()
+    return tuple(t.to(device) for t in (rewards, values, dones, last_values, last_dones))
+
+
+@pytest.mark.parametrize('shape', [(8, 4, 1), (16, 6, 3)])
+@pytest.mark.parametrize('gamma,tau', [(0.99, 0.95), (1.0, 1.0)])
+def test_pytorch_gae_matches_reference(shape, gamma, tau):
+    inputs = make_inputs(*shape)
+    out = _pytorch_gae(*inputs, gamma, tau)
+    ref = reference_gae(*inputs, gamma, tau)
+    assert torch.allclose(out, ref, atol=1e-5)
+
+
+def test_compute_gae_cpu_uses_pytorch_path():
+    inputs = make_inputs(8, 4, 1)
+    out = compute_gae(*inputs, 0.99, 0.95)
+    ref = _pytorch_gae(*inputs, 0.99, 0.95)
+    assert torch.equal(out, ref)
+
+
+@pytest.mark.skipif(not TRITON_CUDA, reason='requires CUDA and triton')
+@pytest.mark.parametrize('shape', [(8, 16, 1), (36, 64, 3), (200, 128, 1)])
+@pytest.mark.parametrize('gamma,tau', [(0.99, 0.95), (1.0, 1.0)])
+def test_triton_matches_pytorch(shape, gamma, tau):
+    from rl_games.triton_kernels.gae_kernel import _triton_gae
+    inputs = make_inputs(*shape, device='cuda')
+    out = _triton_gae(*inputs, gamma, tau)
+    ref = _pytorch_gae(*inputs, gamma, tau)
+    assert torch.allclose(out, ref, atol=1e-4), (out - ref).abs().max().item()
+
+
+@pytest.mark.skipif(not TRITON_CUDA, reason='requires CUDA and triton')
+def test_triton_handles_view_inputs():
+    """Non-contiguous inputs (transposes, slices) must not silently corrupt."""
+    from rl_games.triton_kernels.gae_kernel import _triton_gae
+    horizon, num_envs, value_size = 12, 8, 2
+    rewards, values, dones, last_values, last_dones = make_inputs(
+        horizon, num_envs, value_size + 1, device='cuda')
+    # Last-dim slices and transposed views exercise every stride assumption.
+    rewards = rewards[:, :, :value_size]
+    values = values[:, :, :value_size]
+    last_values = last_values[:, :value_size]
+    dones_t = dones.t().contiguous().t()
+    assert not rewards.is_contiguous()
+    out = _triton_gae(rewards, values, dones_t, last_values, last_dones, 0.99, 0.95)
+    ref = _pytorch_gae(rewards.contiguous(), values.contiguous(), dones,
+                       last_values.contiguous(), last_dones, 0.99, 0.95)
+    assert torch.allclose(out, ref, atol=1e-4)
+
+
+@pytest.mark.skipif(not TRITON_CUDA, reason='requires CUDA and triton')
+def test_triton_all_done_and_no_done_edges():
+    from rl_games.triton_kernels.gae_kernel import _triton_gae
+    rewards, values, dones, last_values, last_dones = make_inputs(10, 4, 1, device='cuda')
+    for fill in (0.0, 1.0):
+        d = torch.full_like(dones, fill)
+        ld = torch.full_like(last_dones, fill)
+        out = _triton_gae(rewards, values, d, last_values, ld, 0.99, 0.95)
+        ref = _pytorch_gae(rewards, values, d, last_values, ld, 0.99, 0.95)
+        assert torch.allclose(out, ref, atol=1e-4)
+
+
+@pytest.mark.parametrize('value', ['1', 'true', 'yes', 'True', ' 1 ', ''])
+def test_rlg_no_triton_env_values_do_not_crash(value):
+    """Any plausible RLG_NO_TRITON value must not break `import rl_games`."""
+    env = dict(os.environ, RLG_NO_TRITON=value)
+    result = subprocess.run(
+        [sys.executable, '-c',
+         'import rl_games.triton_config as tc; print(tc.USE_TRITON)'],
+        env=env, capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+    if value.strip().lower() in ('1', 'true', 'yes'):
+        assert result.stdout.strip() == 'False'


### PR DESCRIPTION
- Hoist triton imports and the @triton.jit kernel to module level: triton resolves kernel symbols through module __globals__, so the function-scoped 'import triton.language as tl' crashed every compile on triton <= 3.3 (torch 2.4-2.7 generation, incl. Isaac Lab stacks) with CompilationError: NameError('tl is not defined'). Module-level definition also makes the JITFunction persistent, so the compile cache hits instead of re-keying every rollout.
- Enforce contiguity in _triton_gae: non-contiguous views previously produced silently wrong advantages (kernel assumes packed layout); load current-step values through the values strides (was rewards).
- gamma/lam passed as runtime scalars, unused num_envs constexpr dropped (no recompile when they change).
- Robust RLG_NO_TRITON parsing ('true'/'yes'/'on'; non-numeric values raised ValueError at import) + one-time backend log.
- tests/test_triton_gae.py: PyTorch path vs independent reference on CPU (CI); triton vs PyTorch on CUDA incl. view inputs and edge dones (skipped without CUDA/triton); env-var parsing.
- Restore the README Triton section removed by the MJLab commit.

Verified: crash reproduced and fix validated on triton 3.0.0 (torch 2.4.1) and triton 3.7.0 (torch 2.12); max |triton - pytorch| <= 2e-6; 30-epoch CartPole GPU run trains with the Triton path active.