### PR TITLE
Add Population Based Training (PBT) observers to rl_games core

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,11 @@ python runner.py --train --file rl_games/configs/atari/ppo_breakout_torch.yaml -
 python runner.py --train --file rl_games/configs/atari/ppo_breakout_torch.yaml --wandb-project-name rl-games-special-test -wandb-entity openrlbenchmark --track
 ```
 
+## Population Based Training
+
+rl_games includes the [DexPBT](https://arxiv.org/abs/2305.12127)-lineage PBT observers
+(previously maintained downstream in IsaacGymEnvs and Isaac Lab), usable with any backend
+via `rl_games.common.pbt` — see [docs/PBT.md](docs/PBT.md).
 
 ## Multi GPU
 

--- a/docs/PBT.md
+++ b/docs/PBT.md
@@ -1,0 +1,80 @@
+# Population Based Training (PBT)
+
+rl_games ships the PBT observer lineage of [DexPBT](https://arxiv.org/abs/2305.12127)
+(previously maintained downstream in
+[IsaacGymEnvs](https://github.com/NVIDIA-Omniverse/IsaacGymEnvs) and Isaac Lab's
+`isaaclab_rl`), now available to any rl_games backend from `rl_games.common.pbt`.
+
+## How it works
+
+Each member of the population is an independent training process with a unique
+`policy_idx`. Every `interval_steps` environment frames, each process:
+
+1. saves a scored checkpoint into a shared workspace directory,
+2. compares its objective against the population
+   (leaders: score > max(mean + `threshold_std`·std, mean + `threshold_abs`);
+   underperformers: the mirror image below the mean),
+3. if it is an underperformer, re-execs itself from a random leader's checkpoint
+   with the whitelisted hyperparameters mutated multiplicatively.
+
+The objective is read from env infos at a dotted address (`objective`), e.g. a task
+success rate — prefer a true task metric over raw reward when reward shaping is
+non-stationary.
+
+## Usage
+
+Attach the observer when constructing the runner:
+
+```python
+from rl_games.common.pbt import PbtAlgoObserver, MultiObserver
+
+observer = MultiObserver([my_other_observer, PbtAlgoObserver(params, args_cli)])
+runner = Runner(algo_observer=observer)
+```
+
+with a `pbt` section in the params:
+
+```yaml
+pbt:
+  enabled: True
+  policy_idx: 0          # unique per process, 0..num_policies-1
+  num_policies: 8
+  directory: ./pbt_run
+  interval_steps: 100000
+  threshold_std: 0.10
+  threshold_abs: 0.05
+  mutation_rate: 0.25
+  change_range: [1.1, 2.0]
+  objective: episode.success
+  mutation:
+    agent.params.config.learning_rate: mutate_float
+    agent.params.config.grad_norm: mutate_float
+    agent.params.config.gamma: mutate_discount
+```
+
+## Restart mechanism and launchers
+
+On replacement the process re-execs itself, rebuilding its original command line with
+`--checkpoint=<leader checkpoint>` plus `key=value` overrides for the mutated
+hyperparameters. This requires a train script whose CLI accepts Hydra-style
+`key=value` overrides (as in Isaac Lab / IsaacGymEnvs `train.py`).
+
+By default the restart uses `sys.executable` (plain Python). Isaac Sim workflows that
+must go through a wrapper set it explicitly:
+
+```yaml
+pbt:
+  launcher: /path/to/_isaac_sim/python.sh
+```
+
+`rl_games/runner.py` does not currently accept `key=value` overrides, so PBT with the
+plain runner requires a thin Hydra-style entry point; native runner support is planned
+alongside the config-management work.
+
+## Mutation functions
+
+- `mutate_float` — multiply or divide by a random factor in `change_range`.
+- `mutate_discount` — mutate `(1 - x)` conservatively (for gamma-like params near 1.0).
+
+Custom functions can be registered by adding to
+`rl_games.common.pbt.mutation.MUTATION_FUNCS`.

--- a/docs/PBT.md
+++ b/docs/PBT.md
@@ -17,9 +17,11 @@ Each member of the population is an independent training process with a unique
 3. if it is an underperformer, re-execs itself from a random leader's checkpoint
    with the whitelisted hyperparameters mutated multiplicatively.
 
-The objective is read from env infos at a dotted address (`objective`), e.g. a task
-success rate — prefer a true task metric over raw reward when reward shaping is
-non-stationary.
+The objective is read from env infos at a dotted address (`objective`) — **required
+when PBT is enabled**, since info layouts differ per backend: e.g.
+`episode.Episode_Reward/success` for Isaac Lab-style nested infos, or `scores` for
+flat info dicts. Steps where the address does not resolve keep the previous score.
+Prefer a true task metric over raw reward when reward shaping is non-stationary.
 
 ## Usage
 

--- a/rl_games/common/algo_observer.py
+++ b/rl_games/common/algo_observer.py
@@ -19,6 +19,9 @@ class AlgoObserver:
     def after_steps(self):
         pass
 
+    def after_clear_stats(self):
+        pass
+
     def after_print_stats(self, frame, epoch_num, total_time):
         pass
 

--- a/rl_games/common/pbt/__init__.py
+++ b/rl_games/common/pbt/__init__.py
@@ -1,0 +1,11 @@
+# Population Based Training (PBT) for rl_games.
+# Ported from the Isaac Lab rl_games integration (isaaclab_rl); original DexPBT
+# implementation from NVIDIA-Omniverse/IsaacGymEnvs (https://arxiv.org/abs/2305.12127).
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers.
+# SPDX-License-Identifier: BSD-3-Clause
+
+from rl_games.common.pbt.mutation import mutate
+from rl_games.common.pbt.pbt import MultiObserver, PbtAlgoObserver
+from rl_games.common.pbt.pbt_cfg import PbtCfg
+
+__all__ = ["MultiObserver", "PbtAlgoObserver", "PbtCfg", "mutate"]

--- a/rl_games/common/pbt/mutation.py
+++ b/rl_games/common/pbt/mutation.py
@@ -1,0 +1,48 @@
+# Ported from the Isaac Lab rl_games integration (isaaclab_rl); original DexPBT
+# implementation from NVIDIA-Omniverse/IsaacGymEnvs (https://arxiv.org/abs/2305.12127).
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import random
+from collections.abc import Callable
+from typing import Any
+
+
+def mutate_float(x: float, change_min: float = 1.1, change_max: float = 1.5) -> float:
+    """Multiply or divide by a random factor in [change_min, change_max]."""
+    k = random.uniform(change_min, change_max)
+    return x / k if random.random() < 0.5 else x * k
+
+
+def mutate_discount(x: float, **kwargs) -> float:
+    """Conservative change near 1.0 by mutating (1 - x) in [1.1, 1.2]."""
+    inv = 1.0 - x
+    new_inv = mutate_float(inv, change_min=1.1, change_max=1.2)
+    return 1.0 - new_inv
+
+
+MUTATION_FUNCS: dict[str, Callable[..., Any]] = {
+    "mutate_float": mutate_float,
+    "mutate_discount": mutate_discount,
+}
+
+
+def mutate(
+    params: dict[str, Any],
+    mutations: dict[str, str],
+    mutation_rate: float,
+    change_range: tuple[float, float],
+) -> dict[str, Any]:
+    cmin, cmax = change_range
+    out: dict[str, Any] = {}
+    for name, val in params.items():
+        fn_name = mutations.get(name)
+        # skip if no rule or coin flip says "no"
+        if fn_name is None or random.random() > mutation_rate:
+            out[name] = val
+            continue
+        fn = MUTATION_FUNCS.get(fn_name)
+        if fn is None:
+            raise KeyError(f"Unknown mutation function: {fn_name!r}")
+        out[name] = fn(val, change_min=cmin, change_max=cmax)
+    return out

--- a/rl_games/common/pbt/mutation.py
+++ b/rl_games/common/pbt/mutation.py
@@ -15,7 +15,11 @@ def mutate_float(x: float, change_min: float = 1.1, change_max: float = 1.5) -> 
 
 
 def mutate_discount(x: float, **kwargs) -> float:
-    """Conservative change near 1.0 by mutating (1 - x) in [1.1, 1.2]."""
+    """Conservative change near 1.0 by mutating (1 - x) in [1.1, 1.2].
+
+    The configured change_range is intentionally ignored: gamma-like params
+    need much smaller steps than regular floats (DexPBT behavior).
+    """
     inv = 1.0 - x
     new_inv = mutate_float(inv, change_min=1.1, change_max=1.2)
     return 1.0 - new_inv

--- a/rl_games/common/pbt/pbt.py
+++ b/rl_games/common/pbt/pbt.py
@@ -20,6 +20,33 @@ from rl_games.common.pbt.pbt_cfg import PbtCfg
 _UNINITIALIZED_VALUE = float(-1e9)
 
 
+def build_restart_args(cli_args, new_params, restart_from_checkpoint,
+                       wandb_args=None, rendering_args=None):
+    """Rebuild the training command line for a PBT restart.
+
+    Drops hydra-style ``key=value`` overrides that are being replaced by
+    ``new_params`` (and any existing checkpoint argument), keeps everything
+    else verbatim, then appends the new checkpoint and the mutated params.
+    """
+    SKIP = ["checkpoint"]
+
+    def keep(arg):
+        if "=" not in arg:
+            return True
+        name = arg.split("=", 1)[0]
+        return name not in new_params and not any(k in name for k in SKIP)
+
+    out = [cli_args[0]] + [arg for arg in cli_args[1:] if keep(arg)]
+    out.append(f"--checkpoint={restart_from_checkpoint}")
+    if wandb_args is not None:
+        out.extend(wandb_args.get_args_list())
+    if rendering_args is not None:
+        out.extend(rendering_args.get_args_list())
+    for param, value in new_params.items():
+        out.append(f"{param}={value}")
+    return out
+
+
 class PbtAlgoObserver(AlgoObserver):
     """rl_games observer that implements Population-Based Training for a single policy process.
 
@@ -49,7 +76,11 @@ class PbtAlgoObserver(AlgoObserver):
         self.wandb_args = pbt_utils.WandbArgs(args_cli)
         self.env_args = pbt_utils.EnvArgs(args_cli)
         self.distributed_args = pbt_utils.DistributedArgs(args_cli)
-        self.cfg = PbtCfg(**params["pbt"])
+        self.cfg = PbtCfg.from_dict(params["pbt"])
+        if not self.cfg.objective:
+            raise ValueError(
+                "pbt.objective is required: a dotted address into env infos, "
+                "e.g. 'episode.Episode_Reward/success' (Isaac Lab) or 'scores' (flat infos)")
         self.pbt_it = -1  # dummy value, stands for "not initialized"
         self.score = _UNINITIALIZED_VALUE
         self.pbt_params = pbt_utils.filter_params(pbt_utils.flatten_dict({"agent": params}), self.cfg.mutation)
@@ -57,7 +88,11 @@ class PbtAlgoObserver(AlgoObserver):
         assert len(self.pbt_params) > 0, "[DANGER]: Dictionary that contains params to mutate is empty"
         self.printer.print_params_table(self.pbt_params, header="List of params to mutate")
 
-        self.device = params.get("params", {}).get("config", {}).get("device", "cpu")
+        if self.distributed_args.distributed and torch.cuda.is_available():
+            # NCCL broadcast requires a CUDA tensor
+            self.device = f'cuda:{int(os.environ.get("LOCAL_RANK", 0))}'
+        else:
+            self.device = params.get("params", {}).get("config", {}).get("device", "cpu")
         self.restart_flag = torch.tensor([0], device=self.device)
 
     def after_init(self, algo):
@@ -82,8 +117,13 @@ class PbtAlgoObserver(AlgoObserver):
             Expects the objective at `infos[self.cfg.objective]` where objective is a dotted address.
         """
         score = infos
-        for part in self.cfg.objective.split("."):
-            score = score[part]
+        try:
+            for part in self.cfg.objective.split("."):
+                score = score[part]
+        except (KeyError, TypeError, IndexError):
+            # the address may not resolve on every step (or every backend);
+            # keep the previous score instead of killing training
+            return
         self.score = score
 
     def after_steps(self):
@@ -184,19 +224,8 @@ class PbtAlgoObserver(AlgoObserver):
         cli_args = sys.argv
         print(f"previous command line args: {cli_args}")
 
-        SKIP = ["checkpoint"]
-        is_hydra = lambda arg: (  # noqa: E731
-            (name := arg.split("=", 1)[0]) not in new_params and not any(k in name for k in SKIP)
-        )
-        modified_args = [cli_args[0]] + [arg for arg in cli_args[1:] if "=" not in arg or is_hydra(arg)]
-
-        modified_args.append(f"--checkpoint={restart_from_checkpoint}")
-        modified_args.extend(self.wandb_args.get_args_list())
-        modified_args.extend(self.rendering_args.get_args_list())
-
-        # add all of the new (possibly mutated) parameters
-        for param, value in new_params.items():
-            modified_args.append(f"{param}={value}")
+        modified_args = build_restart_args(cli_args, new_params, restart_from_checkpoint,
+                                           self.wandb_args, self.rendering_args)
 
         self.algo.writer.flush()
         self.algo.writer.close()

--- a/rl_games/common/pbt/pbt.py
+++ b/rl_games/common/pbt/pbt.py
@@ -1,0 +1,273 @@
+# Ported from the Isaac Lab rl_games integration (isaaclab_rl); original DexPBT
+# implementation from NVIDIA-Omniverse/IsaacGymEnvs (https://arxiv.org/abs/2305.12127).
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import os
+import random
+import sys
+
+import numpy as np
+import torch
+import torch.distributed as dist
+
+from rl_games.common.algo_observer import AlgoObserver
+from rl_games.common.pbt import pbt_utils
+from rl_games.common.pbt.mutation import mutate
+from rl_games.common.pbt.pbt_cfg import PbtCfg
+
+# i.e. value for target objective when it is not known
+_UNINITIALIZED_VALUE = float(-1e9)
+
+
+class PbtAlgoObserver(AlgoObserver):
+    """rl_games observer that implements Population-Based Training for a single policy process.
+
+    Each learner in the population runs as its own process with a unique `policy_idx`. On a
+    fixed cadence (`interval_steps`) every learner saves a scored checkpoint into a shared
+    workspace, compares itself against the population, and — if it is an underperformer —
+    re-execs itself from a leader's checkpoint with mutated hyperparameters.
+
+    Restarts rebuild the original command line, so the launching CLI must accept
+    `key=value` hyperparameter overrides (Hydra style, as in Isaac Lab / IsaacGymEnvs
+    train scripts) and a `--checkpoint=<path>` argument.
+    """
+
+    def __init__(self, params, args_cli=None):
+        """Initialize observer, print the mutation table, and allocate the restart flag.
+
+        Args:
+            params (dict): Full agent/task params (Hydra style), containing a "pbt" section.
+            args_cli: Parsed CLI args used to reconstruct the restart command. Any argparse
+                namespace works; missing attributes are treated as disabled/absent.
+        """
+        super().__init__()
+        self.printer = pbt_utils.PbtTablePrinter()
+        self.dir = params["pbt"]["directory"]
+
+        self.rendering_args = pbt_utils.RenderingArgs(args_cli)
+        self.wandb_args = pbt_utils.WandbArgs(args_cli)
+        self.env_args = pbt_utils.EnvArgs(args_cli)
+        self.distributed_args = pbt_utils.DistributedArgs(args_cli)
+        self.cfg = PbtCfg(**params["pbt"])
+        self.pbt_it = -1  # dummy value, stands for "not initialized"
+        self.score = _UNINITIALIZED_VALUE
+        self.pbt_params = pbt_utils.filter_params(pbt_utils.flatten_dict({"agent": params}), self.cfg.mutation)
+
+        assert len(self.pbt_params) > 0, "[DANGER]: Dictionary that contains params to mutate is empty"
+        self.printer.print_params_table(self.pbt_params, header="List of params to mutate")
+
+        self.device = params.get("params", {}).get("config", {}).get("device", "cpu")
+        self.restart_flag = torch.tensor([0], device=self.device)
+
+    def after_init(self, algo):
+        """Capture training directories on rank 0 and create this policy's workspace folder.
+
+        Args:
+            algo: rl_games algorithm object (provides writer, train_dir, frame counter, etc.).
+        """
+        if self.distributed_args.rank != 0:
+            return
+
+        self.algo = algo
+        self.root_dir = algo.train_dir
+        self.ws_dir = os.path.join(self.root_dir, self.cfg.workspace)
+        self.curr_policy_dir = os.path.join(self.ws_dir, f"{self.cfg.policy_idx:03d}")
+        os.makedirs(self.curr_policy_dir, exist_ok=True)
+
+    def process_infos(self, infos, done_indices):
+        """Extract the scalar objective from environment infos and store in `self.score`.
+
+        Notes:
+            Expects the objective at `infos[self.cfg.objective]` where objective is a dotted address.
+        """
+        score = infos
+        for part in self.cfg.objective.split("."):
+            score = score[part]
+        self.score = score
+
+    def after_steps(self):
+        """Main PBT tick executed every train step.
+
+        Flow:
+            1) Non-zero ranks: exit immediately if `restart_flag == 1`, else return.
+            2) Rank 0: if `restart_flag == 1`, restart this process with new params.
+            3) Rank 0: on PBT cadence boundary (`interval_steps`), save checkpoint,
+               load population checkpoints, compute bands, and if this policy is an
+               underperformer, select a replacement (random leader or self), mutate
+               whitelisted params, set `restart_flag`, broadcast (if distributed),
+               and print a mutation diff table.
+        """
+        if self.distributed_args.distributed:
+            dist.broadcast(self.restart_flag, src=0)
+
+        if self.distributed_args.rank != 0:
+            if self.restart_flag.cpu().item() == 1:
+                os._exit(0)
+            return
+
+        elif self.restart_flag.cpu().item() == 1:
+            self._restart_with_new_params(self.new_params, self.restart_from_checkpoint)
+            return
+
+        if self.pbt_it == -1:
+            self.pbt_it = self.algo.frame // self.cfg.interval_steps
+            return
+
+        if self.algo.frame // self.cfg.interval_steps <= self.pbt_it:
+            return
+
+        self.pbt_it = self.algo.frame // self.cfg.interval_steps
+        frame_left = (self.pbt_it + 1) * self.cfg.interval_steps - self.algo.frame
+        print(f"Policy {self.cfg.policy_idx}, frames_left {frame_left}, PBT it {self.pbt_it}")
+        try:
+            pbt_utils.save_pbt_checkpoint(self.curr_policy_dir, self.score, self.pbt_it, self.algo, self.pbt_params)
+            ckpts = pbt_utils.load_pbt_ckpts(self.ws_dir, self.cfg.policy_idx, self.cfg.num_policies, self.pbt_it)
+            pbt_utils.cleanup(ckpts, self.curr_policy_dir)
+        except Exception as exc:
+            print(f"Policy {self.cfg.policy_idx}: Exception {exc} during sanity log!")
+            return
+
+        sumry = {i: None if c is None else {k: v for k, v in c.items() if k != "params"} for i, c in ckpts.items()}
+        self.printer.print_ckpt_summary(sumry)
+
+        policies = list(range(self.cfg.num_policies))
+        target_objectives = [ckpts[p]["true_objective"] if ckpts[p] else _UNINITIALIZED_VALUE for p in policies]
+        initialized = [(obj, p) for obj, p in zip(target_objectives, policies) if obj > _UNINITIALIZED_VALUE]
+        if not initialized:
+            print("No policies initialized; skipping PBT iteration.")
+            return
+        initialized_objectives, initialized_policies = zip(*initialized)
+
+        # 1) Stats
+        mean_obj = float(np.mean(initialized_objectives))
+        std_obj = float(np.std(initialized_objectives))
+        upper_cut = max(mean_obj + self.cfg.threshold_std * std_obj, mean_obj + self.cfg.threshold_abs)
+        lower_cut = min(mean_obj - self.cfg.threshold_std * std_obj, mean_obj - self.cfg.threshold_abs)
+        leaders = [p for obj, p in zip(initialized_objectives, initialized_policies) if obj > upper_cut]
+        underperformers = [p for obj, p in zip(initialized_objectives, initialized_policies) if obj < lower_cut]
+
+        print(f"mean={mean_obj:.4f}, std={std_obj:.4f}, upper={upper_cut:.4f}, lower={lower_cut:.4f}")
+        print(f"Leaders: {leaders} Underperformers: {underperformers}")
+
+        # 2) Only replace if *this* policy is an underperformer
+        if self.cfg.policy_idx in underperformers:
+            # 3) If there are any leaders, pick one at random; else simply mutate with no replacement
+            replacement_policy_candidate = random.choice(leaders) if leaders else self.cfg.policy_idx
+            print(f"Replacing policy {self.cfg.policy_idx} with {replacement_policy_candidate}.")
+
+            for param, value in self.pbt_params.items():
+                self.algo.writer.add_scalar(f"pbt/{param}", value, self.algo.frame)
+            self.algo.writer.add_scalar("pbt/00_best_objective", max(initialized_objectives), self.algo.frame)
+            self.algo.writer.flush()
+
+            # Decided to replace the policy weights!
+            cur_params = ckpts[replacement_policy_candidate]["params"]
+            self.new_params = mutate(cur_params, self.cfg.mutation, self.cfg.mutation_rate, self.cfg.change_range)
+            self.restart_from_checkpoint = os.path.abspath(ckpts[replacement_policy_candidate]["checkpoint"])
+            self.restart_flag[0] = 1
+            self.printer.print_mutation_diff(cur_params, self.new_params)
+
+    def _get_launcher(self):
+        """The executable used to re-exec training: `pbt.launcher` from config, else sys.executable."""
+        return self.cfg.launcher or sys.executable
+
+    def _restart_with_new_params(self, new_params, restart_from_checkpoint):
+        """Re-exec the current process with a filtered/augmented CLI to apply new params.
+
+        Notes:
+            - Filters out existing Hydra-style overrides that will be replaced,
+              and appends `--checkpoint=<path>` and new param overrides.
+            - On distributed runs, assigns a fresh master port and forwards
+              distributed args to the launcher.
+        """
+        cli_args = sys.argv
+        print(f"previous command line args: {cli_args}")
+
+        SKIP = ["checkpoint"]
+        is_hydra = lambda arg: (  # noqa: E731
+            (name := arg.split("=", 1)[0]) not in new_params and not any(k in name for k in SKIP)
+        )
+        modified_args = [cli_args[0]] + [arg for arg in cli_args[1:] if "=" not in arg or is_hydra(arg)]
+
+        modified_args.append(f"--checkpoint={restart_from_checkpoint}")
+        modified_args.extend(self.wandb_args.get_args_list())
+        modified_args.extend(self.rendering_args.get_args_list())
+
+        # add all of the new (possibly mutated) parameters
+        for param, value in new_params.items():
+            modified_args.append(f"{param}={value}")
+
+        self.algo.writer.flush()
+        self.algo.writer.close()
+
+        if self.wandb_args.enabled:
+            import wandb
+
+            # setdefault only affects the restarted child process
+            os.environ.setdefault("WANDB_RUN_ID", wandb.run.id)  # continue with the same run id
+            os.environ.setdefault("WANDB_RESUME", "allow")  # allow wandb to resume
+            os.environ.setdefault("WANDB_INIT_TIMEOUT", "300")  # give wandb init more time to be fault tolerant
+            wandb.run.finish()
+
+        launcher = self._get_launcher()
+        command = [launcher]
+
+        if self.distributed_args.distributed:
+            self.distributed_args.master_port = str(pbt_utils.find_free_port())
+            command.extend(self.distributed_args.get_args_list())
+        command += [modified_args[0]]
+        command.extend(self.env_args.get_args_list())
+        command += modified_args[1:]
+        if self.distributed_args.distributed:
+            command += ["--distributed"]
+
+        print("Running command:", command, flush=True)
+        print(f"Policy {self.cfg.policy_idx}: Restarting self with args {modified_args}", flush=True)
+
+        pbt_utils.dump_env_sizes()
+
+        # dedup PATH-like env vars so the exec'd child's environment doesn't grow across restarts
+        for var in ("PATH", "PYTHONPATH", "LD_LIBRARY_PATH", "OMNI_USD_RESOLVER_MDL_BUILTIN_PATHS"):
+            val = os.environ.get(var)
+            if not val or os.pathsep not in val:
+                continue
+            seen = set()
+            new_parts = []
+            for p in val.split(os.pathsep):
+                if p and p not in seen:
+                    seen.add(p)
+                    new_parts.append(p)
+            os.environ[var] = os.pathsep.join(new_parts)
+
+        os.execv(launcher, command)
+
+
+class MultiObserver(AlgoObserver):
+    """Meta-observer that allows the user to add several observers."""
+
+    def __init__(self, observers_):
+        super().__init__()
+        self.observers = observers_
+
+    def _call_multi(self, method, *args_, **kwargs_):
+        for o in self.observers:
+            getattr(o, method)(*args_, **kwargs_)
+
+    def before_init(self, base_name, config, experiment_name):
+        self._call_multi("before_init", base_name, config, experiment_name)
+
+    def after_init(self, algo):
+        self._call_multi("after_init", algo)
+
+    def process_infos(self, infos, done_indices):
+        self._call_multi("process_infos", infos, done_indices)
+
+    def after_steps(self):
+        self._call_multi("after_steps")
+
+    def after_clear_stats(self):
+        self._call_multi("after_clear_stats")
+
+    def after_print_stats(self, frame, epoch_num, total_time):
+        self._call_multi("after_print_stats", frame, epoch_num, total_time)

--- a/rl_games/common/pbt/pbt_cfg.py
+++ b/rl_games/common/pbt/pbt_cfg.py
@@ -3,7 +3,7 @@
 # Copyright (c) 2022-2026, The Isaac Lab Project Developers.
 # SPDX-License-Identifier: BSD-3-Clause
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields
 
 
 @dataclass
@@ -31,8 +31,10 @@ class PbtCfg:
     workspace: str = "pbt_workspace"
     """Subfolder under the training dir to isolate this PBT run."""
 
-    objective: str = "Episode_Reward/success"
-    """Dotted address of the scalar objective inside env infos (e.g. 'Episode_Reward/success').
+    objective: str = ""
+    """Dotted address of the scalar objective inside env infos — required when PBT is
+    enabled; there is no portable default (info layouts differ per backend). Examples:
+    'episode.Episode_Reward/success' (Isaac Lab-style nested infos), 'scores' (flat dicts).
     If reward is stationary, a term that corresponds to task success is usually enough; with
     non-stationary rewards, prefer a true task objective."""
 
@@ -63,3 +65,15 @@ class PbtCfg:
     launcher: str = ""
     """Executable used to re-exec the training process on restart. Empty = sys.executable.
     Isaac Lab / Isaac Sim workflows should point this at their python.sh wrapper."""
+
+    def __post_init__(self):
+        self.change_range = tuple(self.change_range)
+
+    @classmethod
+    def from_dict(cls, d):
+        """Build from a config dict, ignoring (and reporting) unknown keys."""
+        known = {f.name for f in fields(cls)}
+        unknown = sorted(set(d) - known)
+        if unknown:
+            print(f"PbtCfg: ignoring unknown config keys {unknown}")
+        return cls(**{k: v for k, v in d.items() if k in known})

--- a/rl_games/common/pbt/pbt_cfg.py
+++ b/rl_games/common/pbt/pbt_cfg.py
@@ -1,0 +1,65 @@
+# Ported from the Isaac Lab rl_games integration (isaaclab_rl); original DexPBT
+# implementation from NVIDIA-Omniverse/IsaacGymEnvs (https://arxiv.org/abs/2305.12127).
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers.
+# SPDX-License-Identifier: BSD-3-Clause
+
+from dataclasses import dataclass, field
+
+
+@dataclass
+class PbtCfg:
+    """
+    Population-Based Training (PBT) configuration.
+
+    Leaders are policies with score > max(mean + threshold_std*std, mean + threshold_abs).
+    Underperformers are policies with score < min(mean - threshold_std*std, mean - threshold_abs).
+    On replacement, selected hyperparameters are mutated multiplicatively in [change_min, change_max].
+    """
+
+    enabled: bool = False
+    """Enable/disable PBT logic."""
+
+    policy_idx: int = 0
+    """Index of this learner in the population (unique in [0, num_policies-1])."""
+
+    num_policies: int = 8
+    """Total number of learners participating in PBT."""
+
+    directory: str = ""
+    """Root directory for PBT artifacts (checkpoints, metadata)."""
+
+    workspace: str = "pbt_workspace"
+    """Subfolder under the training dir to isolate this PBT run."""
+
+    objective: str = "Episode_Reward/success"
+    """Dotted address of the scalar objective inside env infos (e.g. 'Episode_Reward/success').
+    If reward is stationary, a term that corresponds to task success is usually enough; with
+    non-stationary rewards, prefer a true task objective."""
+
+    interval_steps: int = 100_000
+    """Environment steps between PBT iterations (save, compare, replace/mutate)."""
+
+    threshold_std: float = 0.10
+    """Std-based margin k in max(mean ± k·std, mean ± threshold_abs) for leader/underperformer cuts."""
+
+    threshold_abs: float = 0.05
+    """Absolute margin A in max(mean ± threshold_std·std, mean ± A) for leader/underperformer cuts."""
+
+    mutation_rate: float = 0.25
+    """Per-parameter probability of mutation when a policy is replaced."""
+
+    change_range: tuple[float, float] = (1.1, 2.0)
+    """Lower and upper bound of the multiplicative change factor."""
+
+    mutation: dict[str, str] = field(default_factory=dict)
+    """Which parameters to mutate on restart, mapping flattened param address to mutation function:
+        {
+            "agent.params.config.learning_rate": "mutate_float",
+            "agent.params.config.grad_norm": "mutate_float",
+            "agent.params.config.gamma": "mutate_discount",
+        }
+    """
+
+    launcher: str = ""
+    """Executable used to re-exec the training process on restart. Empty = sys.executable.
+    Isaac Lab / Isaac Sim workflows should point this at their python.sh wrapper."""

--- a/rl_games/common/pbt/pbt_utils.py
+++ b/rl_games/common/pbt/pbt_utils.py
@@ -1,0 +1,308 @@
+# Ported from the Isaac Lab rl_games integration (isaaclab_rl); original DexPBT
+# implementation from NVIDIA-Omniverse/IsaacGymEnvs (https://arxiv.org/abs/2305.12127).
+# Copyright (c) 2022-2026, The Isaac Lab Project Developers.
+# SPDX-License-Identifier: BSD-3-Clause
+
+import datetime
+import os
+import random
+import socket
+from collections import OrderedDict
+from pathlib import Path
+
+import yaml
+
+from rl_games.algos_torch.torch_ext import safe_filesystem_op, safe_save
+
+
+class DistributedArgs:
+    """Distributed-launch flags reconstructed for a PBT restart.
+
+    All attribute lookups are defaulted so any argparse namespace (or None) works.
+    """
+
+    def __init__(self, args_cli):
+        self.distributed = getattr(args_cli, "distributed", False)
+        self.nproc_per_node = int(os.environ.get("WORLD_SIZE", 1))
+        self.rank = int(os.environ.get("RANK", 0))
+        self.nnodes = 1
+        self.master_port = getattr(args_cli, "master_port", None)
+
+    def get_args_list(self) -> list[str]:
+        args = ["-m", "torch.distributed.run", f"--nnodes={self.nnodes}", f"--nproc_per_node={self.nproc_per_node}"]
+        if self.master_port:
+            args.append(f"--master_port={self.master_port}")
+        return args
+
+
+class EnvArgs:
+    """Environment CLI flags (Isaac Lab style) forwarded across a PBT restart."""
+
+    def __init__(self, args_cli):
+        self.task = getattr(args_cli, "task", None)
+        seed = getattr(args_cli, "seed", None)
+        self.seed = seed if seed is not None else -1
+        self.headless = getattr(args_cli, "headless", False)
+        self.num_envs = getattr(args_cli, "num_envs", None)
+
+    def get_args_list(self) -> list[str]:
+        args = []
+        if self.task is not None:
+            args.append(f"--task={self.task}")
+        args.append(f"--seed={self.seed}")
+        if self.num_envs is not None:
+            args.append(f"--num_envs={self.num_envs}")
+        if self.headless:
+            args.append("--headless")
+        return args
+
+
+class RenderingArgs:
+    """Rendering/video CLI flags (Isaac Lab style) forwarded across a PBT restart."""
+
+    def __init__(self, args_cli):
+        self.camera_enabled = getattr(args_cli, "enable_cameras", False)
+        self.video = getattr(args_cli, "video", False)
+        self.video_length = getattr(args_cli, "video_length", None)
+        self.video_interval = getattr(args_cli, "video_interval", None)
+
+    def get_args_list(self) -> list[str]:
+        args = []
+        if self.camera_enabled:
+            args.append("--enable_cameras")
+        if self.video:
+            args.extend(["--video", f"--video_length={self.video_length}", f"--video_interval={self.video_interval}"])
+        return args
+
+
+class WandbArgs:
+    """Weights & Biases CLI flags forwarded across a PBT restart."""
+
+    def __init__(self, args_cli):
+        self.enabled = getattr(args_cli, "track", False)
+        self.project_name = getattr(args_cli, "wandb_project_name", None)
+        self.name = getattr(args_cli, "wandb_name", None)
+        self.entity = getattr(args_cli, "wandb_entity", None)
+
+    def get_args_list(self) -> list[str]:
+        args = []
+        if self.enabled:
+            args.append("--track")
+            if self.entity:
+                args.append(f"--wandb-entity={self.entity}")
+            else:
+                raise ValueError("entity must be specified if wandb is enabled")
+            if self.project_name:
+                args.append(f"--wandb-project-name={self.project_name}")
+            if self.name:
+                args.append(f"--wandb-name={self.name}")
+        return args
+
+
+def dump_env_sizes():
+    """Print summary of environment variable usage (count, bytes, top-5 largest, SC_ARG_MAX)."""
+
+    n = len(os.environ)
+    # total bytes in "KEY=VAL\0" for all envp entries
+    total = sum(len(k) + 1 + len(v) + 1 for k, v in os.environ.items())
+    # find the 5 largest values
+    biggest = sorted(os.environ.items(), key=lambda kv: len(kv[1]), reverse=True)[:5]
+
+    print(f"[ENV MONITOR] vars={n}, total_bytes={total}")
+    for k, v in biggest:
+        print(f"    {k!r} length={len(v)} → {v[:60]}{'…' if len(v) > 60 else ''}")
+
+    try:
+        argmax = os.sysconf("SC_ARG_MAX")
+        print(f"[ENV MONITOR] SC_ARG_MAX = {argmax}")
+    except (ValueError, AttributeError):
+        pass
+
+
+def flatten_dict(d, prefix="", separator="."):
+    """Flatten nested dictionaries into a flat dict with keys joined by `separator`."""
+
+    res = dict()
+    for key, value in d.items():
+        if isinstance(value, (dict, OrderedDict)):
+            res.update(flatten_dict(value, prefix + key + separator, separator))
+        else:
+            res[prefix + key] = value
+
+    return res
+
+
+def find_free_port(max_tries: int = 20) -> int:
+    """Return an OS-assigned free TCP port, with a few retries; fall back to a random high port."""
+    for _ in range(max_tries):
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            try:
+                s.bind(("", 0))
+                return s.getsockname()[1]
+            except OSError:
+                continue
+    return random.randint(20000, 65000)
+
+
+def filter_params(params, params_to_mutate):
+    """Filter `params` to only those in `params_to_mutate`, converting str floats (e.g. '1e-4') to float."""
+
+    def try_float(v):
+        if isinstance(v, str):
+            try:
+                return float(v)
+            except ValueError:
+                return v
+        return v
+
+    return {k: try_float(v) for k, v in params.items() if k in params_to_mutate}
+
+
+def save_pbt_checkpoint(workspace_dir, curr_policy_score, curr_iter, algo, params):
+    """Save a PBT checkpoint (.pth and .yaml) with policy state, score, and metadata (rank 0 only)."""
+    if int(os.environ.get("RANK", "0")) == 0:
+        checkpoint_file = os.path.join(workspace_dir, f"{curr_iter:06d}.pth")
+        safe_save(algo.get_full_state_weights(), checkpoint_file)
+        pbt_checkpoint_file = os.path.join(workspace_dir, f"{curr_iter:06d}.yaml")
+
+        pbt_checkpoint = {
+            "iteration": curr_iter,
+            "true_objective": curr_policy_score,
+            "frame": algo.frame,
+            "params": params,
+            "checkpoint": os.path.abspath(checkpoint_file),
+            "pbt_checkpoint": os.path.abspath(pbt_checkpoint_file),
+            "experiment_name": algo.experiment_name,
+        }
+
+        with open(pbt_checkpoint_file, "w") as fobj:
+            yaml.dump(pbt_checkpoint, fobj)
+
+
+def load_pbt_ckpts(workspace_dir, cur_policy_id, num_policies, pbt_iteration) -> dict | None:
+    """
+    Load the latest available PBT checkpoint for each policy (≤ current iteration).
+    Returns a dict mapping policy_idx → checkpoint dict or None. (rank 0 only)
+    """
+    if int(os.environ.get("RANK", "0")) != 0:
+        return None
+    checkpoints = dict()
+    for policy_idx in range(num_policies):
+        checkpoints[policy_idx] = None
+        policy_dir = os.path.join(workspace_dir, f"{policy_idx:03d}")
+
+        if not os.path.isdir(policy_dir):
+            continue
+
+        pbt_checkpoint_files = sorted([f for f in os.listdir(policy_dir) if f.endswith(".yaml")], reverse=True)
+        for pbt_checkpoint_file in pbt_checkpoint_files:
+            iteration = int(pbt_checkpoint_file.split(".")[0])
+
+            ctime_ts = os.path.getctime(os.path.join(policy_dir, pbt_checkpoint_file))
+            created_str = datetime.datetime.fromtimestamp(ctime_ts).strftime("%Y-%m-%d %H:%M:%S")
+
+            if iteration <= pbt_iteration:
+                with open(os.path.join(policy_dir, pbt_checkpoint_file)) as fobj:
+                    now_str = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+                    print(
+                        f"Policy {cur_policy_id} [{now_str}]: Loading"
+                        f" policy-{policy_idx} {pbt_checkpoint_file} (created at {created_str})"
+                    )
+                    checkpoints[policy_idx] = safe_filesystem_op(yaml.load, fobj, Loader=yaml.FullLoader)
+                    break
+
+    return checkpoints
+
+
+def cleanup(checkpoints: dict[int, dict], policy_dir, keep_back: int = 20, max_yaml: int = 50) -> None:
+    """
+    Cleanup old checkpoints for the current policy directory (rank 0 only).
+    - Delete files older than (oldest iteration - keep_back).
+    - Keep at most `max_yaml` latest YAML iterations.
+    """
+    if int(os.environ.get("RANK", "0")) == 0:
+        oldest = min((ckpt["iteration"] if ckpt else 0) for ckpt in checkpoints.values())
+        threshold = max(0, oldest - keep_back)
+        root = Path(policy_dir)
+
+        # group files by numeric iteration (only *.yaml / *.pth)
+        groups: dict[int, list[Path]] = {}
+        for p in root.iterdir():
+            if p.suffix in (".yaml", ".pth") and p.stem.isdigit():
+                groups.setdefault(int(p.stem), []).append(p)
+
+        # 1) drop anything older than threshold
+        for it in [i for i in groups if i <= threshold]:
+            for p in groups[it]:
+                p.unlink(missing_ok=True)
+            groups.pop(it, None)
+
+        # 2) cap total YAML checkpoints: keep newest `max_yaml` iters
+        yaml_iters = sorted((i for i, ps in groups.items() if any(p.suffix == ".yaml" for p in ps)), reverse=True)
+        for it in yaml_iters[max_yaml:]:
+            for p in groups.get(it, []):
+                p.unlink(missing_ok=True)
+            groups.pop(it, None)
+
+
+def _render_table(headers: list[str], rows: list[list]) -> str:
+    """Render a simple fixed-width text table (no external dependencies)."""
+    str_rows = [[str(c) for c in row] for row in rows]
+    widths = [len(h) for h in headers]
+    for row in str_rows:
+        for i, cell in enumerate(row):
+            widths[i] = max(widths[i], len(cell))
+    sep = "+" + "+".join("-" * (w + 2) for w in widths) + "+"
+    line = lambda cells: "| " + " | ".join(c.ljust(w) for c, w in zip(cells, widths)) + " |"  # noqa: E731
+    out = [sep, line(headers), sep]
+    out.extend(line(r) for r in str_rows)
+    out.append(sep)
+    return "\n".join(out)
+
+
+class PbtTablePrinter:
+    """Plain-text table rendering for PBT logs."""
+
+    def __init__(self, *, float_digits: int = 6, path_maxlen: int = 52):
+        self.float_digits = float_digits
+        self.path_maxlen = path_maxlen
+
+    # format helpers
+    def fmt(self, v):
+        return f"{v:.{self.float_digits}g}" if isinstance(v, float) else v
+
+    def short(self, s: str) -> str:
+        s = str(s)
+        L = self.path_maxlen
+        return s if len(s) <= L else s[: L // 2 - 1] + "…" + s[-L // 2 :]
+
+    # tables
+    def print_params_table(self, params: dict, header: str = "Parameters"):
+        rows = [[k, self.fmt(params[k])] for k in sorted(params)]
+        print(header + ":")
+        print(_render_table(["Parameter", "Value"], rows))
+
+    def print_ckpt_summary(self, sumry: dict[int, dict | None]):
+        headers = ["Policy", "Status", "Objective", "Iter", "Frame", "Experiment", "Checkpoint", "YAML"]
+        rows = []
+        for p in sorted(sumry.keys()):
+            c = sumry[p]
+            if c is None:
+                rows.append([p, "—", "", "", "", "", "", ""])
+            else:
+                rows.append([
+                    p,
+                    "OK",
+                    self.fmt(c.get("true_objective", "")),
+                    c.get("iteration", ""),
+                    c.get("frame", ""),
+                    c.get("experiment_name", ""),
+                    self.short(c.get("checkpoint", "")),
+                    self.short(c.get("pbt_checkpoint", "")),
+                ])
+        print(_render_table(headers, rows))
+
+    def print_mutation_diff(self, before: dict, after: dict, *, header: str = "Mutated params (changed only)"):
+        rows = [[k, self.fmt(before[k]), self.fmt(after[k])] for k in sorted(before) if before[k] != after[k]]
+        print(header + ":")
+        print(_render_table(["Parameter", "Old", "New"], rows) if rows else "(no changes)")

--- a/rl_games/common/pbt/pbt_utils.py
+++ b/rl_games/common/pbt/pbt_utils.py
@@ -83,6 +83,10 @@ class WandbArgs:
         self.project_name = getattr(args_cli, "wandb_project_name", None)
         self.name = getattr(args_cli, "wandb_name", None)
         self.entity = getattr(args_cli, "wandb_entity", None)
+        # fail fast: a missing entity would otherwise only surface at restart
+        # time, killing the process mid-training and shrinking the population
+        if self.enabled and not self.entity:
+            raise ValueError("wandb entity must be specified when tracking is enabled")
 
     def get_args_list(self) -> list[str]:
         args = []

--- a/tests/test_pbt.py
+++ b/tests/test_pbt.py
@@ -158,7 +158,7 @@ class TestObserver:
 
     def test_args_cli_none_is_tolerated(self, tmp_path):
         pbt_section = {"enabled": True, "policy_idx": 0, "num_policies": 2,
-                       "directory": str(tmp_path),
+                       "directory": str(tmp_path), "objective": "episode.success",
                        "mutation": {"agent.params.config.learning_rate": "mutate_float"}}
         params = {"pbt": pbt_section, "params": {"config": {"device": "cpu", "learning_rate": 3e-4}}}
         obs = PbtAlgoObserver(params, args_cli=None)
@@ -196,3 +196,110 @@ class TestMultiObserver:
         from rl_games.common.algo_observer import AlgoObserver
         multi = MultiObserver([AlgoObserver()])
         multi.after_clear_stats()  # must not raise: base class defines the full contract
+
+
+class TestReviewFixes:
+
+    def test_objective_required(self, tmp_path):
+        pbt_section = {"enabled": True, "policy_idx": 0, "num_policies": 2,
+                       "directory": str(tmp_path),
+                       "mutation": {"agent.params.config.learning_rate": "mutate_float"}}
+        params = {"pbt": pbt_section, "params": {"config": {"device": "cpu", "learning_rate": 3e-4}}}
+        with pytest.raises(ValueError, match="objective"):
+            PbtAlgoObserver(params, args_cli=None)
+
+    def test_process_infos_missing_key_keeps_previous_score(self, tmp_path):
+        obs = make_observer(tmp_path)
+        obs.process_infos({"episode": {"success": 0.5}}, None)
+        obs.process_infos({"other": 1.0}, None)          # address absent
+        obs.process_infos([1, 2, 3], None)               # wrong container type
+        assert obs.score == 0.5
+
+    def test_unknown_cfg_keys_ignored(self, tmp_path, capsys):
+        obs = make_observer(tmp_path, extra_pbt={"bogus_key": 1, "another": "x"})
+        assert obs.cfg.num_policies == 2
+        assert "bogus_key" in capsys.readouterr().out
+
+    def test_change_range_yaml_list_normalized_to_tuple(self):
+        cfg = PbtCfg(change_range=[1.2, 1.8])
+        assert cfg.change_range == (1.2, 1.8)
+
+    def test_wandb_entity_validated_at_init(self, tmp_path):
+        args = types.SimpleNamespace(track=True, wandb_entity=None)
+        with pytest.raises(ValueError, match="entity"):
+            make_observer(tmp_path.__class__(tmp_path)) if False else pbt_utils.WandbArgs(args)
+
+
+class TestBuildRestartArgs:
+
+    def test_hydra_override_replacement_and_checkpoint_dedup(self):
+        from rl_games.common.pbt.pbt import build_restart_args
+        cli = ["train.py", "task=Lift", "agent.params.config.learning_rate=0.001",
+               "--headless", "--checkpoint=/old/ckpt.pth", "--num_envs", "4096"]
+        new_params = {"agent.params.config.learning_rate": 0.0005}
+        out = build_restart_args(cli, new_params, "/new/ckpt.pth")
+        assert out[0] == "train.py"
+        assert "task=Lift" in out                                  # untouched override kept
+        assert "agent.params.config.learning_rate=0.001" not in out  # replaced override dropped
+        assert "--checkpoint=/old/ckpt.pth" not in out             # old checkpoint dropped
+        assert "--checkpoint=/new/ckpt.pth" in out
+        assert out.count("--num_envs") == 1 and "4096" in out      # two-token args pass through
+        assert out[-1] == "agent.params.config.learning_rate=0.0005"
+
+    def test_wandb_and_rendering_args_appended(self):
+        from rl_games.common.pbt.pbt import build_restart_args
+        wa = pbt_utils.WandbArgs(types.SimpleNamespace(track=True, wandb_entity="me",
+                                                       wandb_project_name="p", wandb_name=None))
+        ra = pbt_utils.RenderingArgs(types.SimpleNamespace(enable_cameras=True, video=False,
+                                                           video_length=None, video_interval=None))
+        out = build_restart_args(["t.py"], {}, "/c.pth", wa, ra)
+        assert "--track" in out and "--wandb-entity=me" in out and "--enable_cameras" in out
+
+
+class BandWriter:
+    def __init__(self):
+        self.scalars = []
+    def add_scalar(self, *a):
+        self.scalars.append(a)
+    def flush(self):
+        pass
+
+
+def synthetic_ckpt(obj, idx):
+    return {"true_objective": obj, "iteration": 1, "frame": 1000,
+            "params": {"agent.params.config.learning_rate": 3e-4},
+            "checkpoint": f"/tmp/pbt_test/{idx}.pth",
+            "pbt_checkpoint": f"/tmp/pbt_test/{idx}.yaml", "experiment_name": "e"}
+
+
+class TestBandLogic:
+
+    def _run_tick(self, tmp_path, monkeypatch, objectives, my_idx=0, seed=3):
+        obs = make_observer(tmp_path, extra_pbt={"policy_idx": my_idx, "num_policies": len(objectives)})
+        algo = FakeAlgo(frame=obs.cfg.interval_steps + 5)
+        algo.writer = BandWriter()
+        algo.train_dir = str(tmp_path)
+        obs.after_init(algo)
+        obs.pbt_it = 0  # cadence: frame//interval == 1 > 0 triggers the tick
+        ckpts = {i: synthetic_ckpt(o, i) for i, o in enumerate(objectives)}
+        monkeypatch.setattr(pbt_utils, "save_pbt_checkpoint", lambda *a, **k: None)
+        monkeypatch.setattr(pbt_utils, "load_pbt_ckpts", lambda *a, **k: ckpts)
+        monkeypatch.setattr(pbt_utils, "cleanup", lambda *a, **k: None)
+        random.seed(seed)
+        obs.after_steps()
+        return obs
+
+    def test_underperformer_gets_replacement_and_restart_flag(self, tmp_path, monkeypatch):
+        obs = self._run_tick(tmp_path, monkeypatch, [1.0, 10.0, 10.5], my_idx=0)
+        assert obs.restart_flag.item() == 1
+        assert obs.restart_from_checkpoint in ("/tmp/pbt_test/1.pth", "/tmp/pbt_test/2.pth")
+        assert set(obs.new_params) == {"agent.params.config.learning_rate"}
+
+    def test_leader_keeps_training(self, tmp_path, monkeypatch):
+        obs = self._run_tick(tmp_path, monkeypatch, [10.5, 10.0, 1.0], my_idx=0)
+        assert obs.restart_flag.item() == 0
+        assert not hasattr(obs, "new_params")
+
+    def test_mid_population_untouched(self, tmp_path, monkeypatch):
+        obs = self._run_tick(tmp_path, monkeypatch, [10.0, 10.1, 9.9], my_idx=0)
+        assert obs.restart_flag.item() == 0

--- a/tests/test_pbt.py
+++ b/tests/test_pbt.py
@@ -1,0 +1,198 @@
+"""Tests for the PBT (Population-Based Training) module: mutation, checkpoint
+save/load/cleanup, config, observer plumbing. All CPU, no training runs."""
+
+import os
+import random
+import types
+
+import pytest
+import torch
+import yaml
+
+from rl_games.common.pbt import PbtAlgoObserver, PbtCfg, MultiObserver, mutate
+from rl_games.common.pbt import pbt_utils
+from rl_games.common.pbt.mutation import mutate_discount, mutate_float
+
+
+class TestMutation:
+
+    def test_mutate_float_bounds(self):
+        random.seed(42)
+        for _ in range(200):
+            x = 1e-4
+            y = mutate_float(x, change_min=1.1, change_max=2.0)
+            factor = y / x if y > x else x / y
+            assert 1.1 <= factor <= 2.0
+
+    def test_mutate_discount_stays_below_one(self):
+        random.seed(42)
+        for _ in range(200):
+            y = mutate_discount(0.99)
+            assert 0.9 < y < 1.0
+
+    def test_mutation_rate_zero_changes_nothing(self):
+        params = {"agent.lr": 3e-4, "agent.gamma": 0.99}
+        rules = {"agent.lr": "mutate_float", "agent.gamma": "mutate_discount"}
+        out = mutate(params, rules, mutation_rate=0.0, change_range=(1.1, 2.0))
+        assert out == params
+
+    def test_mutation_rate_one_changes_all_whitelisted(self):
+        random.seed(1)
+        params = {"agent.lr": 3e-4, "agent.other": 5.0}
+        rules = {"agent.lr": "mutate_float"}
+        out = mutate(params, rules, mutation_rate=1.0, change_range=(1.1, 2.0))
+        assert out["agent.lr"] != params["agent.lr"]
+        assert out["agent.other"] == params["agent.other"]
+
+    def test_unknown_mutation_function_raises(self):
+        random.seed(1)
+        with pytest.raises(KeyError):
+            mutate({"a": 1.0}, {"a": "mutate_bogus"}, mutation_rate=1.0, change_range=(1.1, 2.0))
+
+
+class TestUtils:
+
+    def test_flatten_dict(self):
+        d = {"a": {"b": 1, "c": {"d": 2}}, "e": 3}
+        assert pbt_utils.flatten_dict(d) == {"a.b": 1, "a.c.d": 2, "e": 3}
+
+    def test_filter_params_converts_string_floats(self):
+        params = {"a.lr": "1e-4", "a.name": "ppo", "a.gamma": 0.99}
+        out = pbt_utils.filter_params(params, {"a.lr": "mutate_float", "a.gamma": "mutate_discount"})
+        assert out == {"a.lr": 1e-4, "a.gamma": 0.99}
+        assert isinstance(out["a.lr"], float)
+
+    def test_table_printer_smoke(self, capsys):
+        printer = pbt_utils.PbtTablePrinter()
+        printer.print_params_table({"agent.lr": 3e-4})
+        printer.print_ckpt_summary({0: None, 1: {"true_objective": 1.5, "iteration": 3, "frame": 100,
+                                                 "experiment_name": "x", "checkpoint": "c.pth",
+                                                 "pbt_checkpoint": "c.yaml"}})
+        printer.print_mutation_diff({"a": 1.0}, {"a": 2.0})
+        out = capsys.readouterr().out
+        assert "agent.lr" in out and "true_objective" not in out and "2" in out
+
+
+class FakeAlgo:
+    def __init__(self, frame=0):
+        self.frame = frame
+        self.experiment_name = "fake_exp"
+        self.train_dir = "runs"
+
+    def get_full_state_weights(self):
+        return {"model": torch.zeros(3)}
+
+
+class TestCheckpoints:
+
+    def test_save_load_roundtrip_and_latest_selection(self, tmp_path):
+        ws = tmp_path
+        for policy in (0, 1):
+            pdir = ws / f"{policy:03d}"
+            pdir.mkdir()
+            for it in (1, 2, 3):
+                pbt_utils.save_pbt_checkpoint(str(pdir), 10.0 * policy + it, it, FakeAlgo(frame=it * 1000),
+                                              {"agent.lr": 1e-4})
+        ckpts = pbt_utils.load_pbt_ckpts(str(ws), cur_policy_id=0, num_policies=3, pbt_iteration=2)
+        assert ckpts[0]["iteration"] == 2 and ckpts[0]["true_objective"] == 2.0
+        assert ckpts[1]["iteration"] == 2 and ckpts[1]["true_objective"] == 12.0
+        assert ckpts[2] is None
+        assert os.path.isfile(ckpts[0]["checkpoint"])
+
+    def test_cleanup_drops_old_iterations(self, tmp_path):
+        pdir = tmp_path / "000"
+        pdir.mkdir()
+        for it in range(1, 31):
+            pbt_utils.save_pbt_checkpoint(str(pdir), 1.0, it, FakeAlgo(), {"agent.lr": 1e-4})
+        ckpts = {0: yaml.safe_load((pdir / "000030.yaml").read_text())}
+        pbt_utils.cleanup(ckpts, str(pdir), keep_back=5, max_yaml=50)
+        remaining = sorted(int(p.stem) for p in pdir.glob("*.yaml"))
+        assert min(remaining) == 26 and max(remaining) == 30
+
+
+class TestPbtCfg:
+
+    def test_from_yaml_dict(self):
+        cfg = PbtCfg(**{"enabled": True, "policy_idx": 2, "num_policies": 4,
+                        "directory": "d", "interval_steps": 5000,
+                        "mutation": {"agent.params.config.learning_rate": "mutate_float"}})
+        assert cfg.enabled and cfg.policy_idx == 2 and cfg.num_policies == 4
+        assert cfg.change_range == (1.1, 2.0)
+        assert cfg.launcher == ""
+
+    def test_mutation_default_is_independent(self):
+        a, b = PbtCfg(), PbtCfg()
+        a.mutation["x"] = "mutate_float"
+        assert b.mutation == {}
+
+
+def make_observer(tmp_path, extra_pbt=None):
+    pbt_section = {"enabled": True, "policy_idx": 0, "num_policies": 2,
+                   "directory": str(tmp_path), "interval_steps": 1000,
+                   "objective": "episode.success",
+                   "mutation": {"agent.params.config.learning_rate": "mutate_float"}}
+    pbt_section.update(extra_pbt or {})
+    params = {"pbt": pbt_section,
+              "params": {"config": {"device": "cpu", "learning_rate": 3e-4}}}
+    return PbtAlgoObserver(params, args_cli=types.SimpleNamespace())
+
+
+class TestObserver:
+
+    def test_init_collects_mutable_params(self, tmp_path):
+        obs = make_observer(tmp_path)
+        assert obs.pbt_params == {"agent.params.config.learning_rate": 3e-4}
+        assert obs.cfg.num_policies == 2
+
+    def test_process_infos_dotted_objective(self, tmp_path):
+        obs = make_observer(tmp_path)
+        obs.process_infos({"episode": {"success": 0.75}}, done_indices=None)
+        assert obs.score == 0.75
+
+    def test_default_launcher_is_sys_executable(self, tmp_path):
+        import sys
+        obs = make_observer(tmp_path)
+        assert obs._get_launcher() == sys.executable
+        obs2 = make_observer(tmp_path, extra_pbt={"launcher": "/opt/isaac/python.sh"})
+        assert obs2._get_launcher() == "/opt/isaac/python.sh"
+
+    def test_args_cli_none_is_tolerated(self, tmp_path):
+        pbt_section = {"enabled": True, "policy_idx": 0, "num_policies": 2,
+                       "directory": str(tmp_path),
+                       "mutation": {"agent.params.config.learning_rate": "mutate_float"}}
+        params = {"pbt": pbt_section, "params": {"config": {"device": "cpu", "learning_rate": 3e-4}}}
+        obs = PbtAlgoObserver(params, args_cli=None)
+        assert obs.env_args.get_args_list() == ["--seed=-1"]
+        assert obs.wandb_args.get_args_list() == []
+
+
+class RecordingObserver:
+    def __init__(self):
+        self.calls = []
+
+    def __getattr__(self, name):
+        def record(*args, **kwargs):
+            self.calls.append(name)
+        return record
+
+
+class TestMultiObserver:
+
+    def test_dispatches_all_methods(self):
+        children = [RecordingObserver(), RecordingObserver()]
+        multi = MultiObserver(children)
+        multi.before_init("base", {}, "exp")
+        multi.after_init(FakeAlgo())
+        multi.process_infos({}, None)
+        multi.after_steps()
+        multi.after_clear_stats()
+        multi.after_print_stats(0, 0, 0.0)
+        expected = ["before_init", "after_init", "process_infos", "after_steps",
+                    "after_clear_stats", "after_print_stats"]
+        for child in children:
+            assert child.calls == expected
+
+    def test_plain_algo_observer_child_supports_full_contract(self):
+        from rl_games.common.algo_observer import AlgoObserver
+        multi = MultiObserver([AlgoObserver()])
+        multi.after_clear_stats()  # must not raise: base class defines the full contract


### PR DESCRIPTION
Upstream the DexPBT-lineage PBT implementation (IsaacGymEnvs -> isaaclab_rl) into rl_games/common/pbt/, making population-based training available to any backend instead of Isaac-only downstream copies. BSD-3 provenance headers retained.

Adaptations from the isaaclab_rl version:
- pbt_cfg: isaaclab.utils.configclass -> stdlib dataclass; new optional 'launcher' field.
- Restart no longer hardcodes the Isaac Sim python.sh path (which would resolve relative to the rl_games install dir after the move): defaults to sys.executable, Isaac Sim workflows set pbt.launcher.
- CLI args wrappers tolerate any argparse namespace (or None) via defaulted attribute access, so the existing Isaac Lab call signature PbtAlgoObserver(params, args_cli) works unchanged.
- prettytable dependency replaced with a small plain-text table renderer (no new dependencies).
- AlgoObserver base class gains the missing after_clear_stats no-op (MultiObserver dispatches it; only concrete observers defined it).

Includes tests (mutation bounds/rates, checkpoint save/load/cleanup roundtrip, config, observer plumbing, MultiObserver dispatch) and docs/PBT.md with a README pointer.