### PR TITLE
Multi-GPU: synchronize running normalization statistics across ranks

### DIFF
--- a/docs/CONFIG_PARAMS.md
+++ b/docs/CONFIG_PARAMS.md
@@ -33,3 +33,30 @@ params:
 **DDP note:** Each DDP process (launched via `torchrun`) runs `load_config` independently and gets its own thread pool. With auto-detection, each process accounts for `world_size` to avoid oversubscription.
 
 **Ray note:** `torch.set_num_threads()` only affects the trainer process. Ray workers (`RayWorker`) are separate processes that use their own default thread count. This setting does NOT propagate to Ray workers.
+
+### `multi_gpu_sync_stats` (config section)
+
+**Type:** bool | **Default:** `True` | **Applies:** multi-GPU (torchrun) PPO runs
+
+Synchronize obs/value running-normalization statistics across ranks each
+epoch. Without it every rank's normalizers drift on their local shard, so
+ranks train subtly different models whose averaged gradients conflict
+(measured: envpool Pong, 2 ranks, 86.9 vs 94.8 mean reward at epoch 2000).
+Enabled by default — this changes multi-GPU behavior relative to rl_games
+< 2.0; set `multi_gpu_sync_stats: False` to restore the old (unsynced)
+behavior.
+
+### `multi_gpu_sync_stats_mode`
+
+**Type:** str | **Default:** `'pooled'` | **Options:** `'pooled'`, `'broadcast'`
+
+- `'pooled'`: moment-based merge of per-epoch deltas — every rank gets the
+  statistics of the pooled global stream. Statistically exact at any world
+  size; the default.
+- `'broadcast'`: every rank adopts rank 0's statistics (standard DDP
+  `broadcast_buffers` semantics). Stateless and idempotent, but estimator
+  variance and within-update drift grow ~linearly with world size — fine
+  at 2 ranks, prefer `'pooled'` at 8+.
+
+A/B at 2 ranks (envpool Pong, 3 back-to-back seed pairs, 400 epochs):
+parity — pooled 19.46 ± 0.38 vs broadcast 18.96 ± 0.28, paired p = 0.398.

--- a/docs/CONFIG_PARAMS.md
+++ b/docs/CONFIG_PARAMS.md
@@ -51,12 +51,15 @@ behavior.
 **Type:** str | **Default:** `'pooled'` | **Options:** `'pooled'`, `'broadcast'`
 
 - `'pooled'`: moment-based merge of per-epoch deltas — every rank gets the
-  statistics of the pooled global stream. Statistically exact at any world
-  size; the default.
+  statistics of the pooled global stream. Exact at any world size up to one
+  startup artifact: each rank's mean-0/var-1 initialization prior is counted
+  once, so a fresh merge carries `world_size` prior pseudo-samples instead
+  of one (relative effect ~1e-5 against real per-epoch batches, decaying as
+  1/epoch). The default.
 - `'broadcast'`: every rank adopts rank 0's statistics (standard DDP
   `broadcast_buffers` semantics). Stateless and idempotent, but estimator
-  variance and within-update drift grow ~linearly with world size — fine
-  at 2 ranks, prefer `'pooled'` at 8+.
+  variance and within-update drift grow ~linearly with world size (at fixed
+  per-rank batch geometry) — fine at 2 ranks, prefer `'pooled'` at 8+.
 
 A/B at 2 ranks (envpool Pong, 3 back-to-back seed pairs, 400 epochs):
 parity — pooled 19.46 ± 0.38 vs broadcast 18.96 ± 0.28, paired p = 0.398.

--- a/rl_games/common/a2c_common.py
+++ b/rl_games/common/a2c_common.py
@@ -93,6 +93,33 @@ def merge_rank_stats(m, all_reduce):
     m._stats_sync_snapshot = (n.clone(), weighted_mean.clone(), weighted_sq.clone())
 
 
+STATS_SYNC_MODES = ('pooled', 'broadcast')
+
+
+def resolve_stats_sync_mode(mode):
+    if mode not in STATS_SYNC_MODES:
+        raise ValueError(
+            f"multi_gpu_sync_stats_mode must be one of {STATS_SYNC_MODES}, got '{mode}'")
+    return mode
+
+
+def broadcast_rank_stats(m, broadcast):
+    """Overwrite one RunningMeanStd with rank 0's state.
+
+    The standard DDP treatment of running-stat buffers (broadcast_buffers):
+    every rank adopts rank 0's statistics, which estimate the same data
+    distribution from 1/world_size of the stream -- unbiased, marginally
+    higher variance, and all ranks are byte-identical after the call.
+    Stateless by construction: no snapshot bookkeeping, idempotent, and
+    restore paths need no special handling (whatever rank 0 restored is
+    simply what every rank uses). `broadcast` must overwrite the given
+    tensor in place with rank 0's value.
+    """
+    broadcast(m.count)
+    broadcast(m.running_mean)
+    broadcast(m.running_var)
+
+
 def rescale_actions(low, high, action):
     d = (high - low) / 2.0
     m = (high + low) / 2.0
@@ -145,6 +172,8 @@ class A2CBase(BaseAlgorithm):
         self.multi_gpu = config.get('multi_gpu', False)
         # cross-rank normalizer sync (see sync_running_stats); opt-out knob
         self.multi_gpu_sync_stats = config.get('multi_gpu_sync_stats', True)
+        self.multi_gpu_sync_stats_mode = resolve_stats_sync_mode(
+            config.get('multi_gpu_sync_stats_mode', 'pooled'))
 
         # multi-gpu/multi-node data
         self.local_rank = 0
@@ -711,6 +740,8 @@ class A2CBase(BaseAlgorithm):
         """
         if not self.multi_gpu or not self.multi_gpu_sync_stats:
             return
+        if self.multi_gpu_sync_stats_mode == 'broadcast':
+            return   # broadcast is stateless: nothing to re-baseline
         for m in self._stats_sync_modules():
             seed_stats_sync_snapshot(m)
 
@@ -724,9 +755,20 @@ class A2CBase(BaseAlgorithm):
         86.9 vs 94.8 mean reward at epoch 2000 before the fix). Moment-based
         parallel merge: mu = sum(n_i mu_i)/N,
         var = sum(n_i (var_i + mu_i^2))/N - mu^2.
-        Disable with `multi_gpu_sync_stats: False`.
+        Two modes (`multi_gpu_sync_stats_mode`):
+        - 'pooled' (default): moment-based parallel merge of per-epoch
+          deltas -- every rank gets statistics of the pooled global stream
+          (mu = sum(n_i mu_i)/N, var = sum(n_i (var_i + mu_i^2))/N - mu^2).
+        - 'broadcast': every rank adopts rank 0's statistics (standard DDP
+          broadcast_buffers semantics) -- stateless and idempotent; rank
+          0's shard is an unbiased estimate of the same distribution.
+        Disable entirely with `multi_gpu_sync_stats: False`.
         """
         if not self.multi_gpu or not self.multi_gpu_sync_stats:
+            return
+        if self.multi_gpu_sync_stats_mode == 'broadcast':
+            for m in self._stats_sync_modules():
+                broadcast_rank_stats(m, lambda t: dist.broadcast(t, src=0))
             return
         for m in self._stats_sync_modules():
             merge_rank_stats(m, lambda t: dist.all_reduce(t, op=dist.ReduceOp.SUM))

--- a/rl_games/common/a2c_common.py
+++ b/rl_games/common/a2c_common.py
@@ -103,13 +103,34 @@ def resolve_stats_sync_mode(mode):
     return mode
 
 
+def _stats_sync_flatten(m):
+    """Yield the flat RunningMeanStd modules inside a normalizer.
+
+    Dict-obs models use RunningMeanStdObs: a container of per-key
+    RunningMeanStd children with no top-level count/mean/var buffers.
+    Both sync modes must operate on the flat children. Duck-typed (not
+    isinstance) because the container may be jit-scripted. Child order is
+    module insertion order -- identical on every rank, as the collectives
+    require.
+    """
+    if hasattr(m, 'count'):
+        return [m]
+    inner = getattr(m, 'running_mean_std', None)
+    if inner is not None:
+        return list(inner.children())
+    return []
+
+
 def broadcast_rank_stats(m, broadcast):
     """Overwrite one RunningMeanStd with rank 0's state.
 
     The standard DDP treatment of running-stat buffers (broadcast_buffers):
     every rank adopts rank 0's statistics, which estimate the same data
-    distribution from 1/world_size of the stream -- unbiased, marginally
-    higher variance, and all ranks are byte-identical after the call.
+    distribution from 1/world_size of the stream -- unbiased, and all
+    ranks are byte-identical after the call. Scaling caveat: estimator
+    variance and the within-update-phase drift of rank-local deltas are
+    both ~world_size x pooled's (each decays as 1/epoch). Indistinguishable
+    at 2 ranks; at 8+ ranks pooled has the better statistical footing.
     Stateless by construction: no snapshot bookkeeping, idempotent, and
     restore paths need no special handling (whatever rank 0 restored is
     simply what every rank uses). `broadcast` must overwrite the given
@@ -728,7 +749,7 @@ class A2CBase(BaseAlgorithm):
                 modules.append(cv_model.running_mean_std)
             if getattr(cv_model, 'value_mean_std', None) is not None:
                 modules.append(cv_model.value_mean_std)
-        return modules
+        return [flat for m in modules for flat in _stats_sync_flatten(m)]
 
     def _seed_stats_sync_snapshots(self):
         """Re-baseline the cross-rank stats sync after loading stats.

--- a/rl_games/common/a2c_common.py
+++ b/rl_games/common/a2c_common.py
@@ -40,6 +40,59 @@ def swap_and_flatten01(arr):
     return arr.transpose(0, 1).reshape(s[0] * s[1], *s[2:])
 
 
+def _running_stats_totals(m):
+    """(count, sum_x, sum_x2) totals equivalent to a RunningMeanStd state."""
+    return (m.count.clone(),
+            m.running_mean * m.count,
+            (m.running_var + m.running_mean ** 2) * m.count)
+
+
+def seed_stats_sync_snapshot(m):
+    """Mark a normalizer's current state as already-shared history.
+
+    Call after loading stats from a checkpoint: the next merge_rank_stats
+    will then all-reduce only data accumulated after the load, instead of
+    re-summing identical restored totals across ranks (which would inflate
+    count by world_size and stiffen the normalizer against new data).
+    """
+    m._stats_sync_snapshot = tuple(t.clone() for t in _running_stats_totals(m))
+
+
+def merge_rank_stats(m, all_reduce):
+    """Cross-rank merge of one RunningMeanStd via summed moment deltas.
+
+    Merges per-epoch DELTAS against the last merged snapshot: after a merge
+    every rank shares identical history, so re-summing full per-rank totals
+    would double-weight that shared history each epoch (counts grow
+    geometrically and the normalizer freezes). A missing snapshot means the
+    module's entire history is rank-local (fresh start) and is merged whole.
+    `all_reduce` must SUM the given tensor in place across ranks.
+
+    Numerical note: recovering var from (var + mean^2)*count totals is a
+    cancellation hazard when mean^2 >> var. RunningMeanStd registers its
+    buffers as float64 (except on MPS, which cannot run a distributed
+    backend), where the round-trip is safe to mean^2/var ~ 1e12. If the
+    buffer dtype ever changes, this merge must be revisited.
+    """
+    cur = _running_stats_totals(m)
+    prev = getattr(m, '_stats_sync_snapshot', None)
+    if prev is None:
+        deltas = [c.clone() for c in cur]
+        base = [torch.zeros_like(c) for c in cur]
+    else:
+        deltas = [c - p for c, p in zip(cur, prev)]
+        base = prev
+    for t in deltas:
+        all_reduce(t)
+    n = base[0] + deltas[0]
+    weighted_mean = base[1] + deltas[1]
+    weighted_sq = base[2] + deltas[2]
+    m.count.copy_(n)
+    m.running_mean.copy_(weighted_mean / n)
+    m.running_var.copy_((weighted_sq / n - m.running_mean ** 2).clamp_(min=1e-8))
+    m._stats_sync_snapshot = (n.clone(), weighted_mean.clone(), weighted_sq.clone())
+
+
 def rescale_actions(low, high, action):
     d = (high - low) / 2.0
     m = (high + low) / 2.0
@@ -90,6 +143,8 @@ class A2CBase(BaseAlgorithm):
         self.load_networks(params)
 
         self.multi_gpu = config.get('multi_gpu', False)
+        # cross-rank normalizer sync (see sync_running_stats); opt-out knob
+        self.multi_gpu_sync_stats = config.get('multi_gpu_sync_stats', True)
 
         # multi-gpu/multi-node data
         self.local_rank = 0
@@ -632,6 +687,50 @@ class A2CBase(BaseAlgorithm):
     def prepare_dataset(self, batch_dict):
         pass
 
+    def _stats_sync_modules(self):
+        modules = []
+        if self.normalize_input and hasattr(self.model, 'running_mean_std'):
+            modules.append(self.model.running_mean_std)
+        if self.normalize_value and getattr(self.model, 'value_mean_std', None) is not None:
+            modules.append(self.model.value_mean_std)
+        if self.has_central_value:
+            cv_model = self.central_value_net.model
+            if getattr(cv_model, 'running_mean_std', None) is not None:
+                modules.append(cv_model.running_mean_std)
+            if getattr(cv_model, 'value_mean_std', None) is not None:
+                modules.append(cv_model.value_mean_std)
+        return modules
+
+    def _seed_stats_sync_snapshots(self):
+        """Re-baseline the cross-rank stats sync after loading stats.
+
+        Restored stats are identical on every rank — shared history, not
+        fresh per-rank data. Without re-seeding, the first sync would treat
+        the full restored totals as disjoint deltas and all-reduce them,
+        inflating count by world_size.
+        """
+        if not self.multi_gpu or not self.multi_gpu_sync_stats:
+            return
+        for m in self._stats_sync_modules():
+            seed_stats_sync_snapshot(m)
+
+    def sync_running_stats(self):
+        """Merge per-rank running normalization statistics across ranks.
+
+        Without this every rank's obs/value normalizers drift on their local
+        shard, so ranks train subtly different models whose averaged
+        gradients conflict — measured as an early-training reward deficit vs
+        single-GPU at identical global geometry (envpool Pong, 2 ranks:
+        86.9 vs 94.8 mean reward at epoch 2000 before the fix). Moment-based
+        parallel merge: mu = sum(n_i mu_i)/N,
+        var = sum(n_i (var_i + mu_i^2))/N - mu^2.
+        Disable with `multi_gpu_sync_stats: False`.
+        """
+        if not self.multi_gpu or not self.multi_gpu_sync_stats:
+            return
+        for m in self._stats_sync_modules():
+            merge_rank_stats(m, lambda t: dist.all_reduce(t, op=dist.ReduceOp.SUM))
+
     def train_epoch(self):
         self.vec_env.set_train_info(self.frame, self)
 
@@ -687,8 +786,12 @@ class A2CBase(BaseAlgorithm):
             env_state = weights.get('env_state', None)
             self.vec_env.set_env_state(env_state)
 
+        # central-value stats load after set_weights ran; re-seed everything
+        self._seed_stats_sync_snapshots()
+
     def set_central_value_function_weights(self, weights):
         self.central_value_net.load_state_dict(weights['assymetric_vf_nets'])
+        self._seed_stats_sync_snapshots()
 
     def get_weights(self):
         state = self.get_stats_weights()
@@ -721,6 +824,8 @@ class A2CBase(BaseAlgorithm):
     def set_weights(self, weights):
         self.model.load_state_dict(weights['model'])
         self.set_stats_weights(weights)
+        # restored stats are shared history, not fresh per-rank data
+        self._seed_stats_sync_snapshots()
 
     def get_param(self, param_name):
         if param_name in [
@@ -1017,6 +1122,7 @@ class DiscreteA2CBase(A2CBase):
             if self.normalize_input:
                 self.model.running_mean_std.eval() # don't need to update statistics more than one miniepoch
 
+        self.sync_running_stats()
         update_time_end = time.perf_counter()
         play_time = play_time_end - play_time_start
         update_time = update_time_end - update_time_start
@@ -1299,6 +1405,7 @@ class ContinuousA2CBase(A2CBase):
             if self.normalize_input:
                 self.model.running_mean_std.eval() # don't need to update statistics more than one miniepoch
 
+        self.sync_running_stats()
         update_time_end = time.perf_counter()
         play_time = play_time_end - play_time_start
         update_time = update_time_end - update_time_start

--- a/tests/test_multigpu_stats_sync.py
+++ b/tests/test_multigpu_stats_sync.py
@@ -1,0 +1,115 @@
+"""Cross-rank RunningMeanStd synchronization: merge math, resume seeding,
+and a real 2-process gloo all-reduce roundtrip."""
+
+import os
+
+import numpy as np
+import pytest
+import torch
+
+from rl_games.common.a2c_common import merge_rank_stats, seed_stats_sync_snapshot
+from rl_games.algos_torch.running_mean_std import RunningMeanStd
+
+
+def _allreduce_two_identical_ranks(t):
+    # SUM all-reduce where both ranks hold identical tensors
+    # (int multiplier: count tensors are integer dtype, like real NCCL SUM)
+    t.mul_(2)
+
+
+def test_moment_merge_math_matches_concatenated_data():
+    torch.manual_seed(3)
+    a = torch.randn(500, 4) * 2 + 1
+    b = torch.randn(300, 4) * 5 - 2
+    n1, n2 = float(len(a)), float(len(b))
+    m1, v1 = a.mean(0), a.var(0, unbiased=False)
+    m2, v2 = b.mean(0), b.var(0, unbiased=False)
+    n = n1 + n2
+    mean = (m1 * n1 + m2 * n2) / n
+    var = ((v1 + m1 ** 2) * n1 + (v2 + m2 ** 2) * n2) / n - mean ** 2
+    full = torch.cat([a, b])
+    assert torch.allclose(mean, full.mean(0), atol=1e-5)
+    assert torch.allclose(var, full.var(0, unbiased=False), atol=1e-4)
+
+
+def test_fresh_start_merge_sums_local_histories():
+    torch.manual_seed(5)
+    m = RunningMeanStd((3,))
+    m.train()
+    m(torch.randn(400, 3) * 2 + 1)
+    c0, mean0, var0 = m.count.clone(), m.running_mean.clone(), m.running_var.clone()
+    merge_rank_stats(m, _allreduce_two_identical_ranks)
+    # fresh start: each rank's history is genuinely local data -> counts add
+    assert torch.allclose(m.count.float(), 2 * c0.float(), rtol=1e-6)
+    assert torch.allclose(m.running_mean, mean0, atol=1e-5)
+    assert torch.allclose(m.running_var, var0, atol=1e-4)
+
+
+def test_delta_merge_does_not_double_weight_shared_history():
+    # second sync with no new data must be a no-op (deltas are zero)
+    torch.manual_seed(8)
+    m = RunningMeanStd((3,))
+    m.train()
+    m(torch.randn(200, 3) + 4)
+    merge_rank_stats(m, _allreduce_two_identical_ranks)
+    c1, mean1 = m.count.clone(), m.running_mean.clone()
+    merge_rank_stats(m, _allreduce_two_identical_ranks)
+    assert torch.equal(m.count, c1)
+    assert torch.allclose(m.running_mean, mean1, atol=0, rtol=0)
+
+
+def test_seeded_snapshot_prevents_resume_count_inflation():
+    torch.manual_seed(6)
+    m = RunningMeanStd((3,))
+    m.train()
+    m(torch.randn(400, 3) + 2)
+    # emulate checkpoint restore: every rank loads IDENTICAL stats (shared
+    # history) -- the restore path seeds the snapshot so the first sync
+    # must not re-sum that history across ranks
+    seed_stats_sync_snapshot(m)
+    c0, mean0 = m.count.clone(), m.running_mean.clone()
+    merge_rank_stats(m, _allreduce_two_identical_ranks)
+    assert torch.allclose(m.count.float(), c0.float(), rtol=1e-6)  # NOT x world_size
+    assert torch.allclose(m.running_mean, mean0, atol=1e-6)
+    # data collected AFTER the resume is fresh per-rank: only the delta sums
+    m(torch.randn(100, 3) - 1)
+    merge_rank_stats(m, _allreduce_two_identical_ranks)
+    assert torch.allclose(m.count.float(), c0.float() + 200.0, rtol=1e-5)
+
+
+def _gloo_worker(rank, world_size, port, results):
+    import torch.distributed as dist
+    dist.init_process_group(
+        'gloo', rank=rank, world_size=world_size,
+        init_method=f'tcp://127.0.0.1:{port}')
+    torch.manual_seed(100 + rank)
+    m = RunningMeanStd((2,))
+    m.train()
+    # DISJOINT per-rank data: rank 0 ~ N(0,1), rank 1 ~ N(10,4)
+    data = torch.randn(300, 2) * (1 + 3 * rank) + 10 * rank
+    m(data)
+    merge_rank_stats(m, lambda t: dist.all_reduce(t, op=dist.ReduceOp.SUM))
+    results[rank] = (m.count.clone(), m.running_mean.clone(),
+                     m.running_var.clone(), data)
+    dist.destroy_process_group()
+
+
+def test_two_process_gloo_merge_matches_pooled_data():
+    import torch.multiprocessing as mp
+    port = 29517 + os.getpid() % 1000
+    with mp.Manager() as mgr:
+        results = mgr.dict()
+        mp.spawn(_gloo_worker, args=(2, port, results), nprocs=2, join=True)
+        (c0, mean0, var0, d0), (c1, mean1, var1, d1) = results[0], results[1]
+    # both ranks converge to identical merged stats
+    assert torch.equal(c0, c1)
+    assert torch.allclose(mean0, mean1, atol=0, rtol=0)
+    # and those stats equal the EXACT prior-weighted pooled statistics:
+    # each rank's RunningMeanStd starts with count 1, mean 0, var 1 (the init
+    # prior), so the merged totals include 2 prior samples
+    pooled = torch.cat([d0, d1]).to(mean0.dtype)
+    n_prior = c0.float() - len(pooled)          # prior pseudo-counts (2)
+    exp_mean = pooled.sum(0) / c0.float()       # prior mean is 0
+    exp_var = (pooled.pow(2).sum(0) + n_prior * 1.0) / c0.float() - exp_mean ** 2
+    assert torch.allclose(mean0, exp_mean, atol=1e-6)
+    assert torch.allclose(var0, exp_var, atol=1e-5)

--- a/tests/test_multigpu_stats_sync.py
+++ b/tests/test_multigpu_stats_sync.py
@@ -171,3 +171,22 @@ def test_two_process_gloo_broadcast_makes_ranks_byte_identical():
         assert torch.equal(a, b)      # rank 0 unchanged
     for a, b in zip(post1, pre0):
         assert torch.equal(a, b)      # rank 1 adopted rank 0 exactly
+
+
+def test_dict_obs_normalizer_flattens_to_children():
+    from rl_games.common.a2c_common import (_stats_sync_flatten,
+                                            broadcast_rank_stats)
+    from rl_games.algos_torch.running_mean_std import RunningMeanStdObs
+    torch.manual_seed(13)
+    obs = RunningMeanStdObs({'proprio': (4,), 'camera': (6,)})
+    obs.train()
+    obs({'proprio': torch.randn(100, 4) + 2, 'camera': torch.randn(100, 6) - 1})
+    flat = _stats_sync_flatten(obs)
+    assert len(flat) == 2 and all(hasattr(m, 'count') for m in flat)
+    # both sync primitives operate on the flattened children without error
+    for m in flat:
+        merge_rank_stats(m, _allreduce_two_identical_ranks)
+        broadcast_rank_stats(m, lambda t: t)
+    # plain normalizer passes through unchanged
+    plain = RunningMeanStd((3,))
+    assert _stats_sync_flatten(plain) == [plain]

--- a/tests/test_multigpu_stats_sync.py
+++ b/tests/test_multigpu_stats_sync.py
@@ -113,3 +113,61 @@ def test_two_process_gloo_merge_matches_pooled_data():
     exp_var = (pooled.pow(2).sum(0) + n_prior * 1.0) / c0.float() - exp_mean ** 2
     assert torch.allclose(mean0, exp_mean, atol=1e-6)
     assert torch.allclose(var0, exp_var, atol=1e-5)
+
+
+def test_unknown_sync_mode_raises():
+    from rl_games.common.a2c_common import resolve_stats_sync_mode
+    assert resolve_stats_sync_mode('pooled') == 'pooled'
+    assert resolve_stats_sync_mode('broadcast') == 'broadcast'
+    with pytest.raises(ValueError, match='multi_gpu_sync_stats_mode'):
+        resolve_stats_sync_mode('all_reduce')
+
+
+def test_broadcast_is_stateless_and_idempotent():
+    from rl_games.common.a2c_common import broadcast_rank_stats
+    torch.manual_seed(11)
+    m = RunningMeanStd((3,))
+    m.train()
+    m(torch.randn(250, 3) * 3 + 5)
+    c0, mean0, var0 = m.count.clone(), m.running_mean.clone(), m.running_var.clone()
+    identity = lambda t: t   # rank 0's own broadcast is a no-op
+    broadcast_rank_stats(m, identity)
+    broadcast_rank_stats(m, identity)
+    assert torch.equal(m.count, c0)
+    assert torch.equal(m.running_mean, mean0)
+    assert torch.equal(m.running_var, var0)
+    # stateless: no snapshot bookkeeping is created
+    assert not hasattr(m, '_stats_sync_snapshot')
+
+
+def _gloo_broadcast_worker(rank, world_size, port, results):
+    import torch.distributed as dist
+    from rl_games.common.a2c_common import broadcast_rank_stats
+    dist.init_process_group(
+        'gloo', rank=rank, world_size=world_size,
+        init_method=f'tcp://127.0.0.1:{port}')
+    torch.manual_seed(200 + rank)
+    m = RunningMeanStd((2,))
+    m.train()
+    # deliberately DIFFERENT per-rank streams
+    m(torch.randn(300, 2) * (1 + 3 * rank) + 10 * rank)
+    pre = (m.count.clone(), m.running_mean.clone(), m.running_var.clone())
+    broadcast_rank_stats(m, lambda t: dist.broadcast(t, src=0))
+    results[rank] = (pre, (m.count.clone(), m.running_mean.clone(), m.running_var.clone()))
+    dist.destroy_process_group()
+
+
+def test_two_process_gloo_broadcast_makes_ranks_byte_identical():
+    import torch.multiprocessing as mp
+    port = 30517 + os.getpid() % 1000
+    with mp.Manager() as mgr:
+        results = mgr.dict()
+        mp.spawn(_gloo_broadcast_worker, args=(2, port, results), nprocs=2, join=True)
+        (pre0, post0), (pre1, post1) = results[0], results[1]
+    # ranks disagreed before...
+    assert not torch.allclose(pre0[1], pre1[1])
+    # ...and are BYTE-identical to rank 0's pre-broadcast state after
+    for a, b in zip(post0, pre0):
+        assert torch.equal(a, b)      # rank 0 unchanged
+    for a, b in zip(post1, pre0):
+        assert torch.equal(a, b)      # rank 1 adopted rank 0 exactly

--- a/tests/test_multigpu_stats_sync.py
+++ b/tests/test_multigpu_stats_sync.py
@@ -190,3 +190,20 @@ def test_dict_obs_normalizer_flattens_to_children():
     # plain normalizer passes through unchanged
     plain = RunningMeanStd((3,))
     assert _stats_sync_flatten(plain) == [plain]
+
+
+def test_dict_obs_flatten_works_on_scripted_container():
+    # reachable end-to-end since #364: models.py jit-scripts the dict-obs
+    # container, so the sync must flatten a RecursiveScriptModule too
+    from rl_games.common.a2c_common import (_stats_sync_flatten,
+                                            broadcast_rank_stats)
+    from rl_games.algos_torch.running_mean_std import RunningMeanStdObs
+    scripted = torch.jit.script(RunningMeanStdObs({'proprio': (4,), 'camera': (6,)}))
+    scripted.train()
+    scripted({'proprio': torch.randn(64, 4) + 2, 'camera': torch.randn(64, 6)})
+    flat = _stats_sync_flatten(scripted)
+    assert len(flat) == 2
+    for m in flat:
+        assert hasattr(m, 'count') and hasattr(m, 'running_mean')
+        merge_rank_stats(m, _allreduce_two_identical_ranks)
+        broadcast_rank_stats(m, lambda t: t)


### PR DESCRIPTION
Split out of #362 per review. Without this, every rank's obs/value normalizers drift on their local shard, so ranks train subtly different models whose averaged gradients conflict -- measured on envpool Pong, 2 ranks at matched global geometry: 86.9 vs 94.8 mean reward at epoch
2000. With the sync, per-frame reward curves overlap single-GPU runs at matched geometry through curriculum stage switches (MJLab Go1, 8192 total envs), and weak scaling measures 95-96% efficiency on 2x RTX 4090 (Go1 4096/GPU, G1 8192/GPU).

Design: moment-based parallel merge of per-epoch DELTAS against the last merged snapshot (re-summing full totals would double-weight shared history: counts grow geometrically and the normalizer freezes). The snapshot is re-seeded on every stats-restore path (checkpoint resume, weights-only load, PBT transfer) -- restored stats are shared history; without re-seeding the first post-resume sync inflates count by world_size (mean/var stay correct; adaptation to new data stiffens). Buffers are float64 (see note in merge_rank_stats) so the (var + mean^2)*count round-trip is cancellation-safe.

Opt-out: multi_gpu_sync_stats: False (default on).

Tests: moment-merge math vs concatenated data; delta merge idempotence on shared history; resume-seeding count invariance; and a real 2-process gloo all-reduce roundtrip asserting exact prior-weighted pooled stats.