### PR TITLE
Revive RMS advantage normalization: crash, ignored mask, stale diagnostics

### DIFF
--- a/rl_games/algos_torch/moving_mean_std.py
+++ b/rl_games/algos_torch/moving_mean_std.py
@@ -39,6 +39,16 @@ class GeneralizedMovingStats(nn.Module):
         else:
             raise NotImplementedError(self.impl)
 
+    def get_mean_std(self):
+        """Public accessor for the normalization statistics.
+
+        Returns (offset, invscale) as used for normalization. Note the
+        invscale/std is the EFFECTIVE value: variance is clamped to at
+        least 1/max^2 and eps is added before the square root, so it is
+        not the raw EMA variance (raw: sqrs - mean^2 for 'mean_std').
+        """
+        return self._get_stats()
+
     def _get_stats(self):
         if self.impl == 'off':
             return 0.0, 1.0
@@ -90,6 +100,11 @@ class GeneralizedMovingStats(nn.Module):
         return mean, sqrs
 
     def _update_stats(self, x, mask=None):
+        # EMA semantics: every update moves the statistics by the same decay
+        # regardless of how many (valid) rows the batch carries -- a 3-row
+        # masked batch weighs as much as a 3000-row one. Statistics are also
+        # rank-local under multi-GPU (not covered by the cross-rank sync of
+        # obs/value normalizers; see #363).
         if mask is not None:
             # honor the validity mask: masked-out rows (RNN padding, autoreset
             # filler) must not move the statistics

--- a/rl_games/algos_torch/moving_mean_std.py
+++ b/rl_games/algos_torch/moving_mean_std.py
@@ -19,30 +19,23 @@ class GeneralizedMovingStats(nn.Module):
         self.eps = eps
         self.perclo = perclo
         self.perchi = perchi
+        # statistics are buffers: not learnable, still checkpointed under the
+        # same state_dict keys as the former requires_grad=False Parameters
         if self.impl == 'off':
             pass
-        elif self.impl == 'mean_std':
-            self.step = torch.nn.Parameter(torch.ones((1), dtype=torch.int32), requires_grad=False)
-            self.mean = torch.nn.Parameter(torch.zeros((insize), dtype=torch.float32), requires_grad=False)
-            self.sqrs = torch.nn.Parameter(torch.zeros((insize), dtype=torch.float32), requires_grad=False)
-        elif self.impl == 'mean_std_corr':
-            self.step = torch.nn.Parameter(torch.ones((1), dtype=torch.int32), requires_grad=False)
-            self.mean = torch.nn.Parameter(torch.zeros((insize), dtype=torch.float32), requires_grad=False)
-            self.sqrs = torch.nn.Parameter(torch.zeros((insize), dtype=torch.float32), requires_grad=False)            
-        elif self.impl == 'min_max':
-            self.low = torch.nn.Parameter(torch.zeros((insize), dtype=torch.float32), requires_grad=False)
-            self.high = torch.nn.Parameter(torch.zeros((insize), dtype=torch.float32), requires_grad=False)
-        elif self.impl == 'perc_ema':
-            self.low = torch.nn.Parameter(torch.zeros((insize), dtype=torch.float32), requires_grad=False)
-            self.high = torch.nn.Parameter(torch.zeros((insize), dtype=torch.float32), requires_grad=False)
+        elif self.impl in ('mean_std', 'mean_std_corr'):
+            self.register_buffer('step', torch.ones((1), dtype=torch.int32))
+            self.register_buffer('mean', torch.zeros((insize), dtype=torch.float32))
+            self.register_buffer('sqrs', torch.zeros((insize), dtype=torch.float32))
+        elif self.impl in ('min_max', 'perc_ema'):
+            self.register_buffer('low', torch.zeros((insize), dtype=torch.float32))
+            self.register_buffer('high', torch.zeros((insize), dtype=torch.float32))
         elif self.impl == 'perc_ema_corr':
-            self.step = torch.nn.Parameter(torch.ones((1), dtype=torch.int32), requires_grad=False)
-            self.low = torch.nn.Parameter(torch.zeros((insize), dtype=torch.float32), requires_grad=False)
-            self.high = torch.nn.Parameter(torch.zeros((insize), dtype=torch.float32), requires_grad=False)
-        elif self.impl == 'mean_mag':
-            self.mag = torch.nn.Parameter(torch.zeros((insize), dtype=torch.float32), requires_grad=False)
-        elif self.impl == 'max_mag':
-            self.mag = torch.nn.Parameter(torch.zeros((insize), dtype=torch.float32), requires_grad=False)
+            self.register_buffer('step', torch.ones((1), dtype=torch.int32))
+            self.register_buffer('low', torch.zeros((insize), dtype=torch.float32))
+            self.register_buffer('high', torch.zeros((insize), dtype=torch.float32))
+        elif self.impl in ('mean_mag', 'max_mag'):
+            self.register_buffer('mag', torch.zeros((insize), dtype=torch.float32))
         else:
             raise NotImplementedError(self.impl)
 
@@ -96,18 +89,21 @@ class GeneralizedMovingStats(nn.Module):
         sqrs.mul_(m).add_(mean_factor * x_sqr_mean)
         return mean, sqrs
 
-    def _update_stats(self, x):
+    def _update_stats(self, x, mask=None):
+        if mask is not None:
+            # honor the validity mask: masked-out rows (RNN padding, autoreset
+            # filler) must not move the statistics
+            valid = mask.reshape(-1) > 0
+            if not bool(valid.any()):
+                return
+            x = x[valid]
         m = self.decay
         if self.impl == 'off':
             pass
-        elif self.impl == 'mean_std':
-            self.step.data += 1
-            # Use the compiled function instead of separate operations
-            self.mean, self.sqrs = self.update_moving_stats(self.mean.data, self.sqrs.data, x, m)
-        elif self.impl == 'mean_std_corr':
-            self.step.data += 1
-            # Use the compiled function
-            self.mean, self.sqrs = self.update_moving_stats(self.mean.data, self.sqrs.data, x, m)
+        elif self.impl in ('mean_std', 'mean_std_corr'):
+            self.step += 1
+            # update_moving_stats mutates mean/sqrs in place
+            self.update_moving_stats(self.mean, self.sqrs, x, m)
         elif self.impl == 'min_max':
             low, high = torch.min(x), torch.max(x)
             self.low.data.mul_(m).add_((1 - m) * torch.minimum(self.low.data, low))
@@ -124,7 +120,7 @@ class GeneralizedMovingStats(nn.Module):
 
     def forward(self, input, mask=None, denorm=False):
         if self.training:
-            self._update_stats(input)
+            self._update_stats(input, mask)
 
         offset, invscale = self._get_stats()
         if denorm:

--- a/rl_games/common/diagnostics.py
+++ b/rl_games/common/diagnostics.py
@@ -31,8 +31,9 @@ class PpoDiagnostics(DefaultDiagnostics):
     def epoch(self, agent, current_epoch):
         self.current_epoch = current_epoch
         if agent.normalize_rms_advantage:
-            self.diag_dict['diagnostics/rms_advantage/mean'] = agent.advantage_mean_std.moving_mean
-            self.diag_dict['diagnostics/rms_advantage/var'] = agent.advantage_mean_std.moving_var
+            adv_mean, adv_std = agent.advantage_mean_std._get_stats()
+            self.diag_dict['diagnostics/rms_advantage/mean'] = adv_mean.detach()
+            self.diag_dict['diagnostics/rms_advantage/var'] = (adv_std * adv_std).detach()
         if agent.normalize_value:
             self.diag_dict['diagnostics/rms_value/mean'] = agent.value_mean_std.running_mean
             self.diag_dict['diagnostics/rms_value/var'] = agent.value_mean_std.running_var

--- a/rl_games/common/diagnostics.py
+++ b/rl_games/common/diagnostics.py
@@ -31,7 +31,8 @@ class PpoDiagnostics(DefaultDiagnostics):
     def epoch(self, agent, current_epoch):
         self.current_epoch = current_epoch
         if agent.normalize_rms_advantage:
-            adv_mean, adv_std = agent.advantage_mean_std._get_stats()
+            # effective (clamped + eps) normalization stats, not raw EMA moments
+            adv_mean, adv_std = agent.advantage_mean_std.get_mean_std()
             self.diag_dict['diagnostics/rms_advantage/mean'] = adv_mean.detach()
             self.diag_dict['diagnostics/rms_advantage/var'] = (adv_std * adv_std).detach()
         if agent.normalize_value:

--- a/tests/test_rms_advantage.py
+++ b/tests/test_rms_advantage.py
@@ -1,0 +1,179 @@
+"""RMS advantage normalization (normalize_rms_advantage) revival tests.
+
+The feature was dead since #315: the first statistics update assigned plain
+tensors to nn.Parameter attributes (TypeError), the mask argument was
+silently ignored, and PpoDiagnostics referenced attribute names from the
+pre-#231 predecessor class. Three stacked bugs, each hiding the next.
+"""
+
+import numpy as np
+import pytest
+import torch
+from gymnasium import spaces
+
+from rl_games.algos_torch.moving_mean_std import GeneralizedMovingStats
+from rl_games.common.diagnostics import PpoDiagnostics
+
+
+def test_first_update_does_not_crash_and_converges():
+    torch.manual_seed(0)
+    for impl in ('mean_std', 'mean_std_corr'):
+        gms = GeneralizedMovingStats((1,), impl=impl, decay=0.9)
+        gms.train()
+        for _ in range(300):
+            gms(torch.randn(256) * 2.0 + 3.0)     # the #315 crash site
+        mean, std = gms._get_stats()
+        assert abs(mean.item() - 3.0) < 0.2, (impl, mean)
+        assert abs(std.item() - 2.0) < 0.2, (impl, std)
+
+
+def test_eval_mode_normalizes_without_updating():
+    gms = GeneralizedMovingStats((1,), decay=0.9)
+    gms.train()
+    gms(torch.randn(512) + 5.0)
+    state = {k: v.clone() for k, v in gms.state_dict().items()}
+    gms.eval()
+    out = gms(torch.randn(64) + 5.0)
+    assert torch.isfinite(out).all()
+    for k, v in gms.state_dict().items():
+        assert torch.equal(v, state[k]), k
+
+
+def test_mask_excludes_rows_bit_identically():
+    torch.manual_seed(1)
+    valid = torch.randn(300) + 1.0
+    poison = torch.full((100,), 1e6)
+    x = torch.cat([valid, poison])
+    mask = torch.cat([torch.ones(300), torch.zeros(100)])
+
+    a = GeneralizedMovingStats((1,), decay=0.9)
+    b = GeneralizedMovingStats((1,), decay=0.9)
+    a.train(); b.train()
+    a(valid)
+    b(x, mask=mask)
+    for k in a.state_dict():
+        assert torch.equal(a.state_dict()[k], b.state_dict()[k]), k
+    # mask=None behaves as all-valid
+    c = GeneralizedMovingStats((1,), decay=0.9)
+    c.train()
+    c(x)
+    assert not torch.equal(a.state_dict()['mean'], c.state_dict()['mean'])
+
+
+def test_all_masked_batch_is_a_noop():
+    gms = GeneralizedMovingStats((1,), decay=0.9)
+    gms.train()
+    gms(torch.randn(64))
+    state = {k: v.clone() for k, v in gms.state_dict().items()}
+    gms(torch.full((32,), 1e9), mask=torch.zeros(32))
+    for k, v in gms.state_dict().items():
+        assert torch.equal(v, state[k]), k
+
+
+def test_state_dict_keys_stable_for_old_checkpoints():
+    # stats moved from requires_grad=False Parameters to buffers; the keys
+    # must not change or existing checkpoints break
+    gms = GeneralizedMovingStats((1,))
+    assert set(gms.state_dict().keys()) == {'step', 'mean', 'sqrs'}
+    fresh = GeneralizedMovingStats((1,))
+    fresh.load_state_dict(gms.state_dict())
+
+
+def test_diagnostics_reads_live_attributes():
+    class FakeAgent:
+        normalize_rms_advantage = True
+        normalize_value = False
+        advantage_mean_std = GeneralizedMovingStats((1,), decay=0.9)
+    FakeAgent.advantage_mean_std.train()
+    FakeAgent.advantage_mean_std(torch.randn(128) + 2.0)
+    d = PpoDiagnostics()
+    d.exp_vars = [torch.tensor(0.5)]
+    d.epoch(FakeAgent, current_epoch=1)
+    m = d.diag_dict['diagnostics/rms_advantage/mean']
+    v = d.diag_dict['diagnostics/rms_advantage/var']
+    assert torch.isfinite(m).all() and torch.isfinite(v).all()
+    assert v.item() > 0
+
+
+def test_agent_level_rms_advantage_full_epoch():
+    """The original crash fired inside prepare_dataset on the first epoch --
+    run a real (tiny, CPU) PPO epoch with normalize_rms_advantage on."""
+    from rl_games.torch_runner import Runner
+    from tests.test_sac_correctness import FakeNextStepVecEnv, OBS_DIM
+
+    NUM_ENVS, HORIZON = 4, 16
+
+    class TorchEnvAdapter:
+        def __init__(self, fake):
+            self.fake = fake
+
+        def reset(self):
+            return torch.from_numpy(self.fake.reset())
+
+        def step(self, actions):
+            obs, rew, dones, infos = self.fake.step(actions.detach().cpu().numpy())
+            return (torch.from_numpy(obs), torch.from_numpy(rew),
+                    torch.from_numpy(dones), infos)
+
+        def get_env_info(self):
+            return self.fake.get_env_info()
+
+        def get_env_state(self):
+            return None
+
+        def set_env_state(self, state):
+            pass
+
+        def set_train_info(self, frame, agent):
+            pass
+
+    torch.manual_seed(3)
+    np.random.seed(3)
+    fake = FakeNextStepVecEnv(NUM_ENVS)
+    env = TorchEnvAdapter(fake)
+    params = {
+        'algo': {'name': 'a2c_continuous'},
+        'model': {'name': 'continuous_a2c_logstd'},
+        'network': {
+            'name': 'actor_critic', 'separate': False,
+            'space': {'continuous': {
+                'mu_activation': 'None', 'sigma_activation': 'None',
+                'mu_init': {'name': 'default'},
+                'sigma_init': {'name': 'const_initializer', 'val': 0.0},
+                'fixed_sigma': True}},
+            'mlp': {'units': [16], 'activation': 'elu',
+                    'initializer': {'name': 'default'}},
+        },
+        'config': {
+            'name': 'rms_adv_epoch', 'env_name': 'unused',
+            'reward_shaper': {'scale_value': 1.0},
+            'device': 'cpu', 'multi_gpu': False, 'mixed_precision': False,
+            'normalize_input': False, 'normalize_value': False,
+            'normalize_advantage': True, 'normalize_rms_advantage': True,
+            'adv_rms_momentum': 0.9, 'value_bootstrap': False,
+            'num_actors': NUM_ENVS, 'horizon_length': HORIZON,
+            'minibatch_size': NUM_ENVS * HORIZON, 'mini_epochs': 1,
+            'learning_rate': 1e-4, 'lr_schedule': None, 'kl_threshold': 0.008,
+            'gamma': 0.99, 'tau': 0.95, 'e_clip': 0.2, 'clip_value': False,
+            'critic_coef': 1.0, 'entropy_coef': 0.0, 'truncate_grads': False,
+            'grad_norm': 1.0, 'max_epochs': 1, 'save_frequency': 0,
+            # master's bound_loss returns int 0 without the coef and the loss
+            # assembly crashes on it (latent bug, fixed on the B1 branch);
+            # set it like every shipped continuous config does
+            'bounds_loss_coef': 0.0001,
+            'save_best_after': 10_000, 'print_stats': False,
+            'env_info': fake.get_env_info(),
+        },
+    }
+    runner = Runner()
+    runner.load({'params': params})
+    runner.params['config']['vec_env'] = env
+    agent = runner.algo_factory.create(runner.algo_name, base_name='rms_adv_epoch',
+                                       params=runner.params)
+    assert agent.normalize_rms_advantage
+    agent.init_tensors()
+    agent.obs = agent.env_reset()
+    agent.train_epoch()                       # crashed with TypeError pre-fix
+    assert agent.advantage_mean_std.step.item() > 1
+    mean, std = agent.advantage_mean_std._get_stats()
+    assert torch.isfinite(mean).all() and torch.isfinite(std).all()

--- a/tests/test_rms_advantage.py
+++ b/tests/test_rms_advantage.py
@@ -22,7 +22,7 @@ def test_first_update_does_not_crash_and_converges():
         gms.train()
         for _ in range(300):
             gms(torch.randn(256) * 2.0 + 3.0)     # the #315 crash site
-        mean, std = gms._get_stats()
+        mean, std = gms.get_mean_std()
         assert abs(mean.item() - 3.0) < 0.2, (impl, mean)
         assert abs(std.item() - 2.0) < 0.2, (impl, std)
 
@@ -175,5 +175,5 @@ def test_agent_level_rms_advantage_full_epoch():
     agent.obs = agent.env_reset()
     agent.train_epoch()                       # crashed with TypeError pre-fix
     assert agent.advantage_mean_std.step.item() > 1
-    mean, std = agent.advantage_mean_std._get_stats()
+    mean, std = agent.advantage_mean_std.get_mean_std()
     assert torch.isfinite(mean).all() and torch.isfinite(std).all()


### PR DESCRIPTION
normalize_rms_advantage has been dead since #315: the first statistics update assigned the plain tensors returned by update_moving_stats back to nn.Parameter attributes -- TypeError on epoch 1, every time. Behind that crash sat two more bugs it was masking: forward() accepted a mask (the RNN path passes rnn_masks) and silently ignored it, so padding rows would have biased the statistics; and PpoDiagnostics still read moving_mean/moving_var, attribute names from the class #231 replaced.

Fixes:
- GeneralizedMovingStats statistics move from requires_grad=False Parameters to buffers (same state_dict keys -- old checkpoints load) and the update relies on update_moving_stats' in-place mutation instead of reassigning.
- The mask is honored: masked-out rows are excluded from the update (bit-identical to feeding only the valid rows); an all-masked batch is a no-op.
- Diagnostics derive mean/var from _get_stats().

Tests: first-update crash regression + convergence (both mean_std impls), eval-mode no-update, masked-update bit-identity, all-masked no-op, state_dict key stability, diagnostics, and a full CPU PPO epoch with the feature enabled (the original crash site) -- 6 of 7 fail on unmodified master, all pass here.