### PR TITLE
Checkpoint capability_manifest passthrough (supersedes #357)

### DIFF
--- a/docs/CONFIG_PARAMS.md
+++ b/docs/CONFIG_PARAMS.md
@@ -126,12 +126,19 @@ parity — pooled 19.46 ± 0.38 vs broadcast 18.96 ± 0.28, paired p = 0.398.
 
 ### `capability_manifest`
 
-**Type:** any (opaque) | **Default:** unset | **Applies:** PPO and SAC checkpoints
+**Type:** any | **Default:** unset | **Applies:** PPO and SAC full-state checkpoints
 
-An arbitrary config block stored verbatim in full-state checkpoints and
-restored on load, so metadata travels with the policy (e.g. the command
-ranges or terrain envelope it was trained under, for downstream consumers).
-rl_games takes no position on its schema. On restore, a manifest explicitly
-declared in the current config takes precedence over the checkpoint's (with
-a warning if they differ); otherwise the checkpoint's manifest is adopted
-into the running config.
+Free-form metadata that travels with the policy: whatever this key holds is
+saved into the checkpoint and restored on load. rl_games never interprets
+it. Use it for anything a checkpoint consumer needs to know about the
+policy, for example:
+
+```yaml
+config:
+  capability_manifest:
+    command_ranges: [{quantity: linear_velocity_x, min: -1.5, max: 1.5}]
+    terrain_classes: [rigid]
+```
+
+On restore, a manifest already declared in the config takes precedence over
+the checkpoint's (a warning is printed if they differ).

--- a/docs/CONFIG_PARAMS.md
+++ b/docs/CONFIG_PARAMS.md
@@ -123,3 +123,15 @@ behavior.
 
 A/B at 2 ranks (envpool Pong, 3 back-to-back seed pairs, 400 epochs):
 parity — pooled 19.46 ± 0.38 vs broadcast 18.96 ± 0.28, paired p = 0.398.
+
+### `capability_manifest`
+
+**Type:** any (opaque) | **Default:** unset | **Applies:** PPO and SAC checkpoints
+
+An arbitrary config block stored verbatim in full-state checkpoints and
+restored on load, so metadata travels with the policy (e.g. the command
+ranges or terrain envelope it was trained under, for downstream consumers).
+rl_games takes no position on its schema. On restore, a manifest explicitly
+declared in the current config takes precedence over the checkpoint's (with
+a warning if they differ); otherwise the checkpoint's manifest is adopted
+into the running config.

--- a/rl_games/algos_torch/sac_agent.py
+++ b/rl_games/algos_torch/sac_agent.py
@@ -312,6 +312,13 @@ class SACAgent(BaseAlgorithm):
         if self.save_replay_buffer:
             state['replay_buffer'] = self.replay_buffer.state_dict()
 
+        # Optional capability_manifest passthrough: an opaque config-declared
+        # block stored verbatim so it travels with the policy (rl_games takes
+        # no position on its schema).
+        capability_manifest = self.config.get('capability_manifest')
+        if capability_manifest is not None:
+            state['capability_manifest'] = capability_manifest
+
         return state
 
     def set_full_state_weights(self, weights, set_epoch=True):
@@ -336,6 +343,18 @@ class SACAgent(BaseAlgorithm):
         if self.vec_env is not None:
             env_state = weights.get('env_state', None)
             self.vec_env.set_env_state(env_state)
+
+        # Optional capability_manifest passthrough (see get_full_state_weights).
+        # An explicitly-declared config manifest wins over the checkpoint's:
+        # the running config is the operator's intent, the checkpoint is
+        # history.
+        if 'capability_manifest' in weights:
+            declared = self.config.get('capability_manifest')
+            if declared is not None and declared != weights['capability_manifest']:
+                print('WARNING: config capability_manifest differs from the '
+                      'checkpoint one; keeping the config value')
+            else:
+                self.config['capability_manifest'] = weights['capability_manifest']
 
     def restore(self, fn, set_epoch=True):
         if not os.path.exists(fn):

--- a/rl_games/algos_torch/sac_agent.py
+++ b/rl_games/algos_torch/sac_agent.py
@@ -312,9 +312,9 @@ class SACAgent(BaseAlgorithm):
         if self.save_replay_buffer:
             state['replay_buffer'] = self.replay_buffer.state_dict()
 
-        # Optional capability_manifest passthrough: an opaque config-declared
-        # block stored verbatim so it travels with the policy (rl_games takes
-        # no position on its schema).
+        # If the config declares a `capability_manifest`, store it in the
+        # checkpoint as-is so the metadata travels with the policy.
+        # rl_games never interprets its contents.
         capability_manifest = self.config.get('capability_manifest')
         if capability_manifest is not None:
             state['capability_manifest'] = capability_manifest
@@ -344,10 +344,8 @@ class SACAgent(BaseAlgorithm):
             env_state = weights.get('env_state', None)
             self.vec_env.set_env_state(env_state)
 
-        # Optional capability_manifest passthrough (see get_full_state_weights).
-        # An explicitly-declared config manifest wins over the checkpoint's:
-        # the running config is the operator's intent, the checkpoint is
-        # history.
+        # Adopt the checkpoint's capability_manifest unless the current config
+        # already declares one -- an explicit config value takes precedence.
         if 'capability_manifest' in weights:
             declared = self.config.get('capability_manifest')
             if declared is not None and declared != weights['capability_manifest']:

--- a/rl_games/common/a2c_common.py
+++ b/rl_games/common/a2c_common.py
@@ -840,6 +840,13 @@ class A2CBase(BaseAlgorithm):
             env_state = self.vec_env.get_env_state()
             state['env_state'] = env_state
 
+        # Optional capability_manifest passthrough: an opaque config-declared
+        # block stored verbatim so it travels with the policy (rl_games takes
+        # no position on its schema).
+        capability_manifest = self.config.get('capability_manifest')
+        if capability_manifest is not None:
+            state['capability_manifest'] = capability_manifest
+
         return state
 
     def set_full_state_weights(self, weights, set_epoch=True):
@@ -861,6 +868,18 @@ class A2CBase(BaseAlgorithm):
         if self.vec_env is not None:
             env_state = weights.get('env_state', None)
             self.vec_env.set_env_state(env_state)
+
+        # Optional capability_manifest passthrough (see get_full_state_weights).
+        # An explicitly-declared config manifest wins over the checkpoint's:
+        # the running config is the operator's intent, the checkpoint is
+        # history.
+        if 'capability_manifest' in weights:
+            declared = self.config.get('capability_manifest')
+            if declared is not None and declared != weights['capability_manifest']:
+                print('WARNING: config capability_manifest differs from the '
+                      'checkpoint one; keeping the config value')
+            else:
+                self.config['capability_manifest'] = weights['capability_manifest']
 
         # central-value stats load after set_weights ran; re-seed everything
         self._seed_stats_sync_snapshots()

--- a/rl_games/common/a2c_common.py
+++ b/rl_games/common/a2c_common.py
@@ -840,9 +840,9 @@ class A2CBase(BaseAlgorithm):
             env_state = self.vec_env.get_env_state()
             state['env_state'] = env_state
 
-        # Optional capability_manifest passthrough: an opaque config-declared
-        # block stored verbatim so it travels with the policy (rl_games takes
-        # no position on its schema).
+        # If the config declares a `capability_manifest`, store it in the
+        # checkpoint as-is so the metadata travels with the policy.
+        # rl_games never interprets its contents.
         capability_manifest = self.config.get('capability_manifest')
         if capability_manifest is not None:
             state['capability_manifest'] = capability_manifest
@@ -869,10 +869,8 @@ class A2CBase(BaseAlgorithm):
             env_state = weights.get('env_state', None)
             self.vec_env.set_env_state(env_state)
 
-        # Optional capability_manifest passthrough (see get_full_state_weights).
-        # An explicitly-declared config manifest wins over the checkpoint's:
-        # the running config is the operator's intent, the checkpoint is
-        # history.
+        # Adopt the checkpoint's capability_manifest unless the current config
+        # already declares one -- an explicit config value takes precedence.
         if 'capability_manifest' in weights:
             declared = self.config.get('capability_manifest')
             if declared is not None and declared != weights['capability_manifest']:

--- a/tests/test_capability_manifest.py
+++ b/tests/test_capability_manifest.py
@@ -1,0 +1,75 @@
+"""Optional `capability_manifest` config key rides checkpoints verbatim.
+
+A config may declare an opaque `capability_manifest:` block (e.g. the command
+ranges / terrain envelope a policy was trained under, for downstream
+consumers). rl_games stores it in the checkpoint and restores it on load; an
+explicitly-declared config manifest wins over the checkpoint's on restore.
+
+Reimplementation of #357 (idoco2003) on current master, adding: precedence
+rule, SAC coverage, disk round-trip.
+"""
+import pytest
+
+from tests.test_critical_fixes import make_cartpole_agent
+from tests.test_sac_correctness import make_fake_env_sac_agent
+
+MANIFEST = {
+    "manifest_version": "0.1",
+    "command_ranges": [{"quantity": "linear_velocity_x", "min": -1.5, "max": 1.5}],
+    "terrain_classes": ["rigid"],
+}
+OTHER = {"manifest_version": "0.2", "terrain_classes": ["rough"]}
+
+
+def test_saved_into_checkpoint_and_absent_when_undeclared():
+    agent = make_cartpole_agent(capability_manifest=MANIFEST)
+    assert agent.get_full_state_weights().get("capability_manifest") == MANIFEST
+    agent = make_cartpole_agent()
+    assert "capability_manifest" not in agent.get_full_state_weights()
+
+
+def test_roundtrips_on_restore():
+    state = make_cartpole_agent(capability_manifest=MANIFEST).get_full_state_weights()
+    dst = make_cartpole_agent()
+    assert "capability_manifest" not in dst.config
+    dst.set_full_state_weights(state)
+    assert dst.config["capability_manifest"] == MANIFEST
+
+
+def test_declared_config_manifest_wins_over_checkpoint(capsys):
+    state = make_cartpole_agent(capability_manifest=MANIFEST).get_full_state_weights()
+    dst = make_cartpole_agent(capability_manifest=OTHER)
+    dst.set_full_state_weights(state)
+    assert dst.config["capability_manifest"] == OTHER          # config wins
+    assert 'capability_manifest differs' in capsys.readouterr().out
+    # identical manifests restore silently
+    dst2 = make_cartpole_agent(capability_manifest=MANIFEST)
+    dst2.set_full_state_weights(state)
+    assert dst2.config["capability_manifest"] == MANIFEST
+
+
+def test_disk_roundtrip(tmp_path):
+    src = make_cartpole_agent(capability_manifest=MANIFEST)
+    fn = str(tmp_path / 'manifest_ckpt')
+    src.save(fn)
+    dst = make_cartpole_agent()
+    dst.restore(fn + '.pth')
+    assert dst.config["capability_manifest"] == MANIFEST
+
+
+def test_sac_roundtrip_and_precedence():
+    src, _ = make_fake_env_sac_agent(capability_manifest=MANIFEST)
+    state = src.get_full_state_weights()
+    assert state["capability_manifest"] == MANIFEST
+    dst, _ = make_fake_env_sac_agent()
+    dst.set_full_state_weights(state)
+    assert dst.config["capability_manifest"] == MANIFEST
+    keep, _ = make_fake_env_sac_agent(capability_manifest=OTHER)
+    keep.set_full_state_weights(state)
+    assert keep.config["capability_manifest"] == OTHER
+
+
+def test_value_is_opaque():
+    opaque = {"anything": [1, 2, 3], "nested": {"k": "v"}}
+    agent = make_cartpole_agent(capability_manifest=opaque)
+    assert agent.get_full_state_weights()["capability_manifest"] == opaque

--- a/tests/test_capability_manifest.py
+++ b/tests/test_capability_manifest.py
@@ -1,12 +1,12 @@
-"""Optional `capability_manifest` config key rides checkpoints verbatim.
+"""The optional `capability_manifest` config key travels with checkpoints.
 
-A config may declare an opaque `capability_manifest:` block (e.g. the command
-ranges / terrain envelope a policy was trained under, for downstream
-consumers). rl_games stores it in the checkpoint and restores it on load; an
-explicitly-declared config manifest wins over the checkpoint's on restore.
+Whatever the config declares under `capability_manifest` is saved into
+full-state checkpoints and restored on load (PPO and SAC). rl_games never
+interprets it. On restore, a manifest declared in the current config wins
+over the checkpoint's.
 
-Reimplementation of #357 (idoco2003) on current master, adding: precedence
-rule, SAC coverage, disk round-trip.
+Reimplementation of #357 (idoco2003), adding: precedence rule, SAC
+coverage, disk round-trip.
 """
 import pytest
 


### PR DESCRIPTION
Reimplementation of idoco2003's #357 on current master: an opaque config-declared capability_manifest block is stored verbatim in full-state checkpoints and restored on load, for PPO and SAC. Changes vs #357, per review: an explicitly-declared config manifest wins over the checkpoint's on restore (warning on mismatch) instead of being silently clobbered; SAC path has test coverage; disk round-trip through save()/restore() tested; the config key is documented in CONFIG_PARAMS.md.

Old checkpoints load unchanged (key-presence guarded); new checkpoints carry one extra dict key that old rl_games ignores.