### PR TITLE
Vm/fix/release blockers

### DIFF
--- a/notebooks/mjlab_training_colab.ipynb
+++ b/notebooks/mjlab_training_colab.ipynb
@@ -83,7 +83,7 @@
    "outputs": [],
    "source": [
     "# rl_games from git until the 2.0 PyPI release (then: %pip install rl-games mjlab mediapy)\n",
-    "RL_GAMES_REF = 'VM/feature/b1-ppo'   # flip to 'master' after the branch merges, PyPI after release\n",
+    "RL_GAMES_REF = 'master'   # flip to the PyPI pin after the 2.0 release\n",
     "\n",
     "import subprocess, sys\n",
     "subprocess.check_call([sys.executable, '-m', 'pip', 'install', '-q',\n",

--- a/rl_games/algos_torch/sac_agent.py
+++ b/rl_games/algos_torch/sac_agent.py
@@ -142,6 +142,13 @@ class SACAgent(BaseAlgorithm):
         # ────────────────────────────────────
         # Summary writer
         # ────────────────────────────────────
+        if config.get('multi_gpu', False):
+            # SAC has no gradient/parameter synchronization: torchrun would
+            # silently train independent seed-offset agents racing on the
+            # same checkpoint paths. Refuse rather than mistrain.
+            raise NotImplementedError(
+                'multi_gpu is not supported for SAC (no DDP/gradient sync); '
+                'distributed training is PPO-only for now')
         self.global_rank = int(os.getenv("RANK", "0"))
 
         if self.global_rank == 0:

--- a/rl_games/common/a2c_common.py
+++ b/rl_games/common/a2c_common.py
@@ -847,6 +847,11 @@ class A2CBase(BaseAlgorithm):
         if capability_manifest is not None:
             state['capability_manifest'] = capability_manifest
 
+        # adaptive-LR scheduler state: without these, resume restarts the
+        # adaptive walk from the config LR (KL spike after late resumes)
+        state['last_lr'] = self.last_lr
+        state['entropy_coef'] = self.entropy_coef
+
         return state
 
     def set_full_state_weights(self, weights, set_epoch=True):
@@ -878,6 +883,10 @@ class A2CBase(BaseAlgorithm):
                       'checkpoint one; keeping the config value')
             else:
                 self.config['capability_manifest'] = weights['capability_manifest']
+
+        # old checkpoints lack these keys: keep config-derived values then
+        self.last_lr = weights.get('last_lr', self.last_lr)
+        self.entropy_coef = weights.get('entropy_coef', self.entropy_coef)
 
         # central-value stats load after set_weights ran; re-seed everything
         self._seed_stats_sync_snapshots()

--- a/rl_games/common/a2c_common.py
+++ b/rl_games/common/a2c_common.py
@@ -360,7 +360,7 @@ class A2CBase(BaseAlgorithm):
         if 'seq_len' in config:
             print('WARNING: seq_len is deprecated, use seq_length instead')
 
-        self.seq_length = self.config.get('seq_length', 4)
+        self.seq_length = self.config.get('seq_length', self.config.get('seq_len', 4))
         print('seq_length:', self.seq_length)
         self.bptt_len = self.config.get('bptt_length', self.seq_length) # not used right now; never showed a benefit
         self.zero_rnn_on_done = self.config.get('zero_rnn_on_done', True)

--- a/rl_games/configs/atari/ppo_pacman_torch_rnn.yaml
+++ b/rl_games/configs/atari/ppo_pacman_torch_rnn.yaml
@@ -73,7 +73,7 @@ params:
     minibatch_size: 1024
     mini_epochs: 4
     critic_coef: 1
-    seq_len: 16
+    seq_length: 16
     lr_schedule:  linear
     schedule_entropy: True
     normalize_input: False

--- a/rl_games/torch_runner.py
+++ b/rl_games/torch_runner.py
@@ -193,7 +193,7 @@ class Runner:
         self.algo_name = self.algo_params['name']
         self.exp_config = None
 
-        if self.seed:
+        if self.seed is not None:
             torch.manual_seed(self.seed)
             torch.cuda.manual_seed_all(self.seed)
             np.random.seed(self.seed)

--- a/tests/test_release_blockers.py
+++ b/tests/test_release_blockers.py
@@ -34,3 +34,14 @@ def test_seed_zero_actually_seeds():
     np.random.seed(0)
     expected = (torch.rand(3).tolist(), np.random.rand(3).tolist())
     assert draws[0] == expected
+
+
+def test_legacy_seq_len_falls_back_instead_of_silently_dropping():
+    # the deprecation warning implied the old key still worked; it was
+    # discarded and the RNN silently trained with seq_length=4 (a shipped
+    # config, ppo_pacman_torch_rnn.yaml, hit this)
+    # (batch is 16 in the tiny factory: keep seq values divisible)
+    agent = make_cartpole_agent(seq_len=8)
+    assert agent.seq_length == 8
+    agent = make_cartpole_agent(seq_len=4, seq_length=8)   # new key wins
+    assert agent.seq_length == 8

--- a/tests/test_release_blockers.py
+++ b/tests/test_release_blockers.py
@@ -45,3 +45,12 @@ def test_legacy_seq_len_falls_back_instead_of_silently_dropping():
     assert agent.seq_length == 8
     agent = make_cartpole_agent(seq_len=4, seq_length=8)   # new key wins
     assert agent.seq_length == 8
+
+
+def test_sac_rejects_multi_gpu():
+    # SAC reads RANK only to gate the writer -- no DDP wrapper, no gradient
+    # collective. torchrun silently trained N independent agents racing on
+    # the same checkpoint files. Refuse loudly until real support exists.
+    from tests.test_sac_correctness import make_fake_env_sac_agent
+    with pytest.raises(NotImplementedError, match='multi_gpu is not supported for SAC'):
+        make_fake_env_sac_agent(multi_gpu=True)

--- a/tests/test_release_blockers.py
+++ b/tests/test_release_blockers.py
@@ -1,0 +1,36 @@
+"""Regression tests for the 2.0 release-blocker batch (silent-wrong-behavior
+class): seed 0, legacy seq_len, SAC multi_gpu guard, adaptive-LR resume."""
+
+import copy
+
+import numpy as np
+import pytest
+import torch
+
+from rl_games.torch_runner import Runner
+from tests.test_critical_fixes import (_load_params, CARTPOLE_YAML,
+                                       make_cartpole_agent)
+
+
+def _load_runner_with_seed(seed):
+    # seed is a TOP-LEVEL params key (not config), so build params directly
+    params = _load_params(CARTPOLE_YAML)
+    params['seed'] = seed
+    r = Runner()
+    r.load({'params': copy.deepcopy(params)})
+    return r
+
+
+def test_seed_zero_actually_seeds():
+    # seed: 0 is a conventional choice; `if self.seed:` treated it as falsy and
+    # silently skipped ALL seeding while logging that seed 0 was in effect
+    draws = []
+    for _ in range(2):
+        _load_runner_with_seed(0)
+        draws.append((torch.rand(3).tolist(), np.random.rand(3).tolist()))
+    assert draws[0] == draws[1], 'seed 0 did not seed torch/numpy'
+    # and seed 0 is genuinely seed 0, not some other stream
+    torch.manual_seed(0)
+    np.random.seed(0)
+    expected = (torch.rand(3).tolist(), np.random.rand(3).tolist())
+    assert draws[0] == expected

--- a/tests/test_release_blockers.py
+++ b/tests/test_release_blockers.py
@@ -54,3 +54,25 @@ def test_sac_rejects_multi_gpu():
     from tests.test_sac_correctness import make_fake_env_sac_agent
     with pytest.raises(NotImplementedError, match='multi_gpu is not supported for SAC'):
         make_fake_env_sac_agent(multi_gpu=True)
+
+
+def test_adaptive_lr_state_survives_resume():
+    # the optimizer LR was checkpointed but last_lr was not: after restore the
+    # next scheduler.update restarted the adaptive walk from the config LR
+    # (up to ~30x too high late in training -- KL spike on resume)
+    src = make_cartpole_agent()
+    src.last_lr = 3.7e-5
+    src.entropy_coef = 0.0123
+    state = src.get_full_state_weights()
+    dst = make_cartpole_agent()
+    assert dst.last_lr != 3.7e-5
+    dst.set_full_state_weights(state)
+    assert dst.last_lr == 3.7e-5
+    assert dst.entropy_coef == 0.0123
+    # old checkpoints without the keys keep config-derived values
+    for k in ('last_lr', 'entropy_coef'):
+        state.pop(k)
+    legacy = make_cartpole_agent()
+    before = (legacy.last_lr, legacy.entropy_coef)
+    legacy.set_full_state_weights(state)
+    assert (legacy.last_lr, legacy.entropy_coef) == before


### PR DESCRIPTION
Release-blocker batch: four silent-wrong-behavior fixes + notebook chore.
One commit per fix; every fix ships a regression test, and the seed/seq_len tests 
are proven to fail on unpatched master.

**`seed: 0` now actually seeds** — `if self.seed:` treated 0 as unset and
silently skipped torch/numpy/python/env seeding while logging that seed 0
was active. Guard on `is not None` (`None` still means "derive from time").

**`seq_len` fallback** — the deprecation warning implied the legacy key
still worked; it was discarded and RNNs silently trained with
`seq_length=4`. The legacy value is now used as a fallback (`seq_length`
wins when both are set), and the one shipped config still using the old
key (`ppo_pacman_torch_rnn.yaml`, 16) is migrated.

**SAC rejects `multi_gpu: true`** — SAC reads `RANK` only to gate the
writer; with no DDP wrapper or gradient collective, torchrun trained N
independent seed-offset agents racing on the same checkpoint files.
Raises `NotImplementedError` until real support lands (distributed
training is PPO-only).

**Adaptive-LR resume state** — the optimizer LR was checkpointed but
`last_lr`/`entropy_coef` were not, so the first `scheduler.update` after a
resume restarted the adaptive walk from the config LR (up to ~30× too
high after a late-training resume → KL spike). Both are now saved and
restored; old checkpoints without the keys keep config-derived values,
and multi-GPU composes with the existing rank-0 broadcast in `update_lr`.

**Chore:** the Colab notebook installs rl_games from `master` now that the
B1 branch is merged (flips to the PyPI pin at release).

175 tests green on the rebased tip.
