### PR TITLE
Warm-start the obs normalizer count (normalize_input_init_count)

### DIFF
--- a/docs/CONFIG_PARAMS.md
+++ b/docs/CONFIG_PARAMS.md
@@ -142,3 +142,59 @@ config:
 
 On restore, a manifest already declared in the config takes precedence over
 the checkpoint's (a warning is printed if they differ).
+
+## Observation Normalization (under `config:`)
+
+### `normalize_input`
+
+Enables online observation normalization: a `RunningMeanStd` tracks per-dimension
+mean/variance of the observations and the model normalizes every input with the
+current stats. Stats update on each training minibatch forward (train mode) and
+are frozen during rollouts and evaluation; they are part of the checkpoint.
+
+```yaml
+config:
+  normalize_input: True
+```
+
+**Default:** `False`. Applies to the PPO agents (`a2c_continuous`,
+`a2c_discrete`) and, when configured in `central_value_config`, to the central
+value network. SAC has its own `normalize_input` handling and is not affected by
+the warm-start parameter below.
+
+### `normalize_input_init_count`
+
+Seeds the sample count of the obs normalizer's zero-mean/unit-variance prior.
+With the legacy count of 1, the first training minibatch outweighs the prior
+thousands to one and the running stats jump straight to the batch stats; the
+policy recomputed under the shifted stats diverges from the rollout policy that
+collected the data (a large first-epoch KL — with `lr_schedule: adaptive` this
+can floor the LR at `min_lr` in epoch 1 before learning starts). A larger count
+turns that jump into a damped update.
+
+```yaml
+config:
+  normalize_input: True
+  normalize_input_init_count: 81920   # explicit prior weight (int or 8.2e4)
+  # normalize_input_init_count: 1     # legacy cold start
+  # omit or null                      # auto: one PPO epoch of samples (default)
+```
+
+**Default (`null`/absent):** `mini_epochs * horizon_length * num_actors *
+num_agents` — one PPO epoch of *counted* samples (the normalizer updates on
+every training minibatch, so its count accrues `mini_epochs`× the rollout size
+per epoch; the derivation matches that accounting). The prior then fades after
+roughly one epoch. Values below 1 are rejected (a 0 or negative count poisons
+the running stats).
+
+**Multi-GPU:** with pooled stats sync, the first merge sums every rank's seeded
+prior, so the effective prior weight is exactly one *global* epoch — consistent
+with the single-GPU behavior.
+
+**Scope and follow-ups:** this seeds the *input* normalizer of the PPO agents
+and the central value network. `value_mean_std` (`normalize_value`) has the
+same cold start and is a planned follow-up; SAC is unaffected. Note the warm
+start damps the first-epoch stat jump but does not change the update scheme
+itself — stats still drift within each epoch (updated per minibatch over the
+same rollout data); collection-time freezing à la VecNormalize would remove
+that drift entirely and remains a possible future change.

--- a/rl_games/algos_torch/a2c_continuous.py
+++ b/rl_games/algos_torch/a2c_continuous.py
@@ -33,6 +33,7 @@ class A2CAgent(a2c_common.ContinuousA2CBase):
             'value_size': self.env_info.get('value_size', 1),
             'normalize_value': self.normalize_value,
             'normalize_input': self.normalize_input,
+            'normalize_input_init_count': self.normalize_input_init_count,
         }
 
         self.model = self.network.build(build_config)

--- a/rl_games/algos_torch/a2c_continuous.py
+++ b/rl_games/algos_torch/a2c_continuous.py
@@ -64,7 +64,8 @@ class A2CAgent(a2c_common.ContinuousA2CBase):
                 'writter': self.writer,
                 'max_epochs': self.max_epochs,
                 'multi_gpu': self.multi_gpu,
-                'zero_rnn_on_done': self.zero_rnn_on_done
+                'zero_rnn_on_done': self.zero_rnn_on_done,
+                'normalize_input_init_count': self.normalize_input_init_count
             }
             self.central_value_net = central_value.CentralValueTrain(**cv_config).to(self.ppo_device)
 

--- a/rl_games/algos_torch/a2c_discrete.py
+++ b/rl_games/algos_torch/a2c_discrete.py
@@ -66,7 +66,8 @@ class DiscreteA2CAgent(a2c_common.DiscreteA2CBase):
                 'writter': self.writer,
                 'max_epochs': self.max_epochs,
                 'multi_gpu': self.multi_gpu,
-                'zero_rnn_on_done': self.zero_rnn_on_done
+                'zero_rnn_on_done': self.zero_rnn_on_done,
+                'normalize_input_init_count': self.normalize_input_init_count
             }
             self.central_value_net = central_value.CentralValueTrain(**cv_config).to(self.ppo_device)
 

--- a/rl_games/algos_torch/a2c_discrete.py
+++ b/rl_games/algos_torch/a2c_discrete.py
@@ -36,6 +36,7 @@ class DiscreteA2CAgent(a2c_common.DiscreteA2CBase):
             'value_size': self.env_info.get('value_size', 1),
             'normalize_value': self.normalize_value,
             'normalize_input': self.normalize_input,
+            'normalize_input_init_count': self.normalize_input_init_count,
         }
 
         self.model = self.network.build(config)

--- a/rl_games/algos_torch/central_value.py
+++ b/rl_games/algos_torch/central_value.py
@@ -16,7 +16,7 @@ class CentralValueTrain(nn.Module):
     def __init__(
         self, state_shape, value_size, ppo_device, num_agents, horizon_length, num_actors,
         num_actions, seq_length, normalize_value, network, config, writter, max_epochs,
-        multi_gpu, zero_rnn_on_done
+        multi_gpu, zero_rnn_on_done, normalize_input_init_count=1
     ):
         nn.Module.__init__(self)
 
@@ -45,6 +45,7 @@ class CentralValueTrain(nn.Module):
             'num_agents': num_agents,
             'num_seqs': num_actors,
             'normalize_input': self.normalize_input,
+            'normalize_input_init_count': normalize_input_init_count,
             'normalize_value': self.normalize_value,
         }
 

--- a/rl_games/algos_torch/models.py
+++ b/rl_games/algos_torch/models.py
@@ -30,13 +30,15 @@ class BaseModel():
         obs_shape = config['input_shape']
         normalize_value = config.get('normalize_value', False)
         normalize_input = config.get('normalize_input', False)
+        obs_init_count = config.get('normalize_input_init_count') or 1
         value_size = config.get('value_size', 1)
         return self.Network(self.network_builder.build(self.model_class, **config), obs_shape=obs_shape,
-            normalize_value=normalize_value, normalize_input=normalize_input, value_size=value_size)
+            normalize_value=normalize_value, normalize_input=normalize_input, value_size=value_size,
+            obs_init_count=obs_init_count)
 
 
 class BaseModelNetwork(nn.Module):
-    def __init__(self, obs_shape, normalize_value, normalize_input, value_size):
+    def __init__(self, obs_shape, normalize_value, normalize_input, value_size, obs_init_count=1):
         nn.Module.__init__(self)
         self.obs_shape = obs_shape
         self.normalize_value = normalize_value
@@ -47,9 +49,9 @@ class BaseModelNetwork(nn.Module):
             self.value_mean_std = torch.jit.script(RunningMeanStd((self.value_size,)))
         if normalize_input:
             if isinstance(obs_shape, dict):
-                self.running_mean_std = torch.jit.script(RunningMeanStdObs(obs_shape))
+                self.running_mean_std = torch.jit.script(RunningMeanStdObs(obs_shape, init_count=obs_init_count))
             else:
-                self.running_mean_std = torch.jit.script(RunningMeanStd(obs_shape))
+                self.running_mean_std = torch.jit.script(RunningMeanStd(obs_shape, init_count=obs_init_count))
 
     def norm_obs(self, observation):
         with torch.no_grad():

--- a/rl_games/algos_torch/models.py
+++ b/rl_games/algos_torch/models.py
@@ -30,7 +30,7 @@ class BaseModel():
         obs_shape = config['input_shape']
         normalize_value = config.get('normalize_value', False)
         normalize_input = config.get('normalize_input', False)
-        obs_init_count = config.get('normalize_input_init_count') or 1
+        obs_init_count = int(float(config.get('normalize_input_init_count') or 1))
         value_size = config.get('value_size', 1)
         return self.Network(self.network_builder.build(self.model_class, **config), obs_shape=obs_shape,
             normalize_value=normalize_value, normalize_input=normalize_input, value_size=value_size,

--- a/rl_games/algos_torch/running_mean_std.py
+++ b/rl_games/algos_torch/running_mean_std.py
@@ -18,7 +18,7 @@ def _running_stats_dtype():
 
 class RunningMeanStd(nn.Module):
     """Tracks the running mean and variance of input data."""
-    def __init__(self, insize, epsilon=1e-05, per_channel=False, norm_only=False):
+    def __init__(self, insize, epsilon=1e-05, per_channel=False, norm_only=False, init_count=1):
         super(RunningMeanStd, self).__init__()
         print('RunningMeanStd: ', insize)
         self.insize = insize
@@ -50,7 +50,13 @@ class RunningMeanStd(nn.Module):
         # long training run can hit and silently freezes the running stats.
         # Module._apply skips non-floating buffers, so .half()/.float() leave
         # this one alone too.
-        self.register_buffer("count", torch.ones((), dtype=torch.int64))
+        # init_count seeds the sample count of the zero-mean/unit-var prior.
+        # With the historical value of 1 the very first update batch outweighs
+        # the prior thousands to one and the stats jump straight to the batch
+        # stats, which recomputes early train-time policies far away from the
+        # rollout policy that collected the data (a large first-epoch KL). A
+        # larger init_count turns that jump into a damped update.
+        self.register_buffer("count", torch.full((), int(init_count), dtype=torch.int64))
 
     def _update_mean_var_count_from_moments(self, mean, var, count, batch_mean, batch_var, batch_count:int):
         # count is int64; cast to the float dtype for arithmetic only.
@@ -116,11 +122,11 @@ class RunningMeanStd(nn.Module):
 
 class RunningMeanStdObs(nn.Module):
     """Maintains running statistics for each observation key provided as a dictionary."""
-    def __init__(self, insize, epsilon=1e-05, per_channel=False, norm_only=False):
+    def __init__(self, insize, epsilon=1e-05, per_channel=False, norm_only=False, init_count=1):
         assert(isinstance(insize, dict))
         super(RunningMeanStdObs, self).__init__()
         self.running_mean_std = nn.ModuleDict({
-            k: RunningMeanStd(v, epsilon, per_channel, norm_only) for k, v in insize.items()
+            k: RunningMeanStd(v, epsilon, per_channel, norm_only, init_count) for k, v in insize.items()
         })
 
     def forward(self, input: Dict[str, torch.Tensor], denorm: bool = False) -> Dict[str, torch.Tensor]:

--- a/rl_games/common/a2c_common.py
+++ b/rl_games/common/a2c_common.py
@@ -165,6 +165,38 @@ def print_statistics(print_stats, curr_frames, step_time, step_inference_time, t
             print(f'fps step: {fps_step:.0f} fps step and policy inference: {fps_step_inference:.0f} fps total: {fps_total:.0f} epoch: {epoch_num:.0f}/{max_epochs:.0f} frames: {frame:.0f}/{max_frames:.0f}')
 
 
+
+def resolve_obs_norm_init_count(value, mini_epochs, batch_size):
+    """Resolve `normalize_input_init_count` from the config.
+
+    None (the default) derives one PPO epoch of *counted* samples: the obs
+    normalizer updates on every training minibatch (set_train() re-enables
+    updates before each epoch), so its count accrues mini_epochs * batch_size
+    per epoch — the derivation matches that accounting, not the number of
+    unique frames. If stat updates ever move to collection time (one update
+    per rollout), drop the mini_epochs factor here or the prior becomes
+    mini_epochs times too heavy. Under multi-GPU pooled stats sync the first
+    merge sums every rank's seeded prior, so the effective prior weight is
+    exactly one *global* epoch.
+
+    Explicit values are validated: YAML scientific notation may arrive as a
+    float or a string (`8.2e4`), so cast via float; anything below 1 is an
+    error (a count of 0 or negative silently poisons the running stats).
+    """
+    if value is None:
+        return mini_epochs * batch_size
+    try:
+        count = int(float(value))
+    except (TypeError, ValueError):
+        raise ValueError(
+            f"normalize_input_init_count must be a number >= 1 or null, got {value!r}")
+    if count < 1:
+        raise ValueError(
+            f"normalize_input_init_count must be >= 1, got {value!r}; "
+            "use 1 for the legacy cold start")
+    return count
+
+
 class A2CBase(BaseAlgorithm):
 
     def __init__(self, base_name, params):
@@ -424,14 +456,11 @@ class A2CBase(BaseAlgorithm):
         self.mini_epochs_num = self.config['mini_epochs']
         # obs-normalizer warm-start: seed the running-stat count so the fresh
         # zero-mean/unit-var prior is not overwritten by the first minibatch.
-        # None (the default) derives one PPO epoch of samples — early updates
-        # then nudge the stats, keeping the first epoch's recomputed policy
-        # close to the rollout policy (small KL) instead of divorcing them.
-        # Set 1 to restore the legacy cold start.
-        init_count = self.config.get('normalize_input_init_count', None)
-        if init_count is None:
-            init_count = self.mini_epochs_num * self.batch_size
-        self.normalize_input_init_count = init_count
+        # See resolve_obs_norm_init_count for the default derivation and its
+        # coupling to the per-minibatch update accounting.
+        self.normalize_input_init_count = resolve_obs_norm_init_count(
+            self.config.get('normalize_input_init_count', None),
+            self.mini_epochs_num, self.batch_size)
 
         # bf16 autocast is enabled by default on capable GPUs; set
         # mixed_precision: False in the config to opt out. bf16 has fp32's

--- a/rl_games/common/a2c_common.py
+++ b/rl_games/common/a2c_common.py
@@ -422,6 +422,16 @@ class A2CBase(BaseAlgorithm):
             )
 
         self.mini_epochs_num = self.config['mini_epochs']
+        # obs-normalizer warm-start: seed the running-stat count so the fresh
+        # zero-mean/unit-var prior is not overwritten by the first minibatch.
+        # None (the default) derives one PPO epoch of samples — early updates
+        # then nudge the stats, keeping the first epoch's recomputed policy
+        # close to the rollout policy (small KL) instead of divorcing them.
+        # Set 1 to restore the legacy cold start.
+        init_count = self.config.get('normalize_input_init_count', None)
+        if init_count is None:
+            init_count = self.mini_epochs_num * self.batch_size
+        self.normalize_input_init_count = init_count
 
         # bf16 autocast is enabled by default on capable GPUs; set
         # mixed_precision: False in the config to opt out. bf16 has fp32's

--- a/tests/test_obs_norm_init_count.py
+++ b/tests/test_obs_norm_init_count.py
@@ -1,0 +1,69 @@
+"""normalize_input_init_count: warm-started running-stat count.
+
+With the legacy count of 1, the first update batch outweighs the unit prior
+thousands to one, so the stats jump straight to the batch stats — recomputing
+early train-time policies far from the rollout policy that collected the data
+(observed as a huge first-epoch KL). Seeding the count damps that jump.
+"""
+import torch
+
+from rl_games.algos_torch.running_mean_std import RunningMeanStd, RunningMeanStdObs
+
+torch.manual_seed(0)
+
+
+def stats(rms):
+    return rms.running_mean.clone(), rms.running_var.clone(), rms.count.item()
+
+
+def test_legacy_cold_start_jumps():
+    rms = RunningMeanStd((4,))
+    rms.train()
+    batch = torch.randn(2048, 4) * 3.0 + 5.0
+    rms(batch)
+    mean, var, count = stats(rms)
+    # count 1: stats essentially become the batch stats in one update
+    assert torch.allclose(mean.float(), batch.mean(0), atol=0.02)
+    assert count == 1 + 2048
+
+
+def test_init_count_damps_first_update():
+    rms = RunningMeanStd((4,), init_count=10 * 2048)
+    rms.train()
+    batch = torch.randn(2048, 4) * 3.0 + 5.0
+    rms(batch)
+    mean, var, count = stats(rms)
+    # prior weighs 10 update batches: first update moves the mean ~1/11 of the way
+    expected = batch.mean(0).double() * (2048.0 / (10 * 2048 + 2048))
+    assert torch.allclose(mean, expected, atol=0.02)
+    assert count == 10 * 2048 + 2048
+    # and it converges toward the data stats once enough batches arrive
+    # (the prior still carries 20480/(20480+201*2048) ~ 4.7% of the weight)
+    for _ in range(200):
+        rms(torch.randn(2048, 4) * 3.0 + 5.0)
+    mean, var, _ = stats(rms)
+    assert torch.allclose(mean.float(), torch.full((4,), 5.0), atol=0.35)
+    assert torch.allclose(var.float(), torch.full((4,), 9.0), rtol=0.2)
+
+
+def test_normalization_uses_prior_early():
+    rms = RunningMeanStd((4,), init_count=10 * 2048)
+    rms.train()
+    batch = torch.randn(2048, 4) * 3.0 + 5.0
+    out = rms(batch)
+    # with the prior dominant, normalization is still ~identity (mean 0, var 1)
+    assert out.mean().abs() > 1.0  # raw offset survives: (5 - ~0.45) / ~1.9
+
+
+def test_dict_obs_pass_through():
+    rms = RunningMeanStdObs({'a': (3,), 'b': (2,)}, init_count=1234)
+    for m in rms.running_mean_std.values():
+        assert m.count.item() == 1234
+
+
+if __name__ == '__main__':
+    test_legacy_cold_start_jumps()
+    test_init_count_damps_first_update()
+    test_normalization_uses_prior_early()
+    test_dict_obs_pass_through()
+    print('obs-norm init-count tests passed')

--- a/tests/test_obs_norm_init_count.py
+++ b/tests/test_obs_norm_init_count.py
@@ -67,3 +67,31 @@ if __name__ == '__main__':
     test_normalization_uses_prior_early()
     test_dict_obs_pass_through()
     print('obs-norm init-count tests passed')
+
+
+def test_resolution_and_validation():
+    from rl_games.common.a2c_common import resolve_obs_norm_init_count as resolve
+    # default derivation: one PPO epoch of counted samples
+    assert resolve(None, 5, 16384) == 5 * 16384
+    # legacy opt-out
+    assert resolve(1, 5, 16384) == 1
+    # YAML scientific notation can arrive as float or string
+    assert resolve(8.2e4, 5, 16384) == 82000
+    assert resolve("8.2e4", 5, 16384) == 82000
+    assert resolve("1e6", 5, 16384) == 1000000
+    # anything below 1 poisons the running stats: reject loudly
+    for bad in (0, 0.9, -16, "0", "-1e3"):
+        try:
+            resolve(bad, 5, 16384)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError(f"{bad!r} must raise")
+    # garbage types raise too
+    for bad in ("auto", [1]):
+        try:
+            resolve(bad, 5, 16384)
+        except ValueError:
+            pass
+        else:
+            raise AssertionError(f"{bad!r} must raise")


### PR DESCRIPTION
## Problem

The input `RunningMeanStd` starts with `count = 1`. The first training minibatch (thousands of rows) outweighs the zero-mean/unit-var prior thousands to one, so the running stats jump straight to the batch stats within the first few updates. The policy recomputed under these shifted stats is then far from the rollout policy that collected the data — through no fault of the optimizer, and independent of the learning rate.

Measured on envpool MyoSuite `myoHandPoseRandom-v0`: first-epoch KL of **~68** vs a `kl_threshold` of 0.008 (an LSTM policy shows the same mechanism at smaller scale, ~0.077). With `lr_schedule: adaptive` the spike slams the LR to `min_lr` within the first epochs; because steady-state KL then sits inside the adaptive band, the LR never recovers and the whole run trains at the floor. Disabling `normalize_input` drops the first-epoch KL to 0.78, isolating the normalizer as the cause.

## Fix

Seed the running-stat count so the unit prior has weight and early updates *nudge* the stats instead of overwriting them:

```yaml
config:
  normalize_input: true
  normalize_input_init_count: 81920   # optional; None/absent = auto
```

- **Default (`None`/absent): one PPO epoch of samples** — `mini_epochs * horizon_length * num_actors * num_agents`. Self-scales to the setup; the prior fades after roughly one epoch.
- **`1` restores the legacy cold start** (this PR changes the default behavior — flagged deliberately, see below).

## Measurements

First-epoch KL, transformer policy on `myoHandPoseRandom` (identical config, LR pinned at 5e-5):

| init_count | epoch-1 KL |
|---|---|
| 1 (legacy) | 68.7 |
| 10 × minibatch (20,480) | 8.76 |
| 1 epoch = default (81,920) | **3.13** |
| 100 × minibatch (204,800) | 1.87 |

KL decays to steady state within ~4 epochs in all cases; probe-horizon rewards unaffected.

## Notes

- Threaded through `a2c_continuous` and `a2c_discrete`; `RunningMeanStdObs` (dict obs) forwards the count to each per-key normalizer.
- Value normalization (`normalize_value`) has the same cold-start mechanically; left untouched here to keep the change scoped — can follow up if wanted.
- Unit tests in `tests/test_obs_norm_init_count.py`; e2e-smoked on envpool MyoSuite with the auto default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0136YrDc8orFywMHFX9Do7BT