### PR TITLE
Ant envpool config: 128 actors, minibatch 4096

### DIFF
--- a/rl_games/configs/mujoco/ant_envpool.yaml
+++ b/rl_games/configs/mujoco/ant_envpool.yaml
@@ -49,9 +49,9 @@ params:
     bound_loss_type: regularisation
     bounds_loss_coef: 0.0
     max_epochs: 2000
-    num_actors: 64
+    num_actors: 128
     horizon_length: 64
-    minibatch_size: 2048
+    minibatch_size: 4096
     mini_epochs: 4
     critic_coef: 2
 


### PR DESCRIPTION
Config-only. Two-seed, same-window measurement on envpool 1.2.6: 128 actors / mb 4096 hits 6256-6411 reward at epoch 2000 vs 3253 for 64 actors at the same epoch (second seed; the first fell into the flipped-ant optimum and never recovered). Budget stays 2000 epochs (+4-7% only by 4000). HalfCheetah 2K probe showed +3.6% over 1K — its config left unchanged. Curves in the tuning TensorBoard (ant_4k_* runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)