### PR TITLE
AdaptiveScheduler: default max_lr 1e-2 -> 1e-3

### DIFF
--- a/docs/CONFIG_PARAMS.md
+++ b/docs/CONFIG_PARAMS.md
@@ -47,7 +47,7 @@ config:
   schedule_type: per_minibatch   # default; 'legacy' is a permanent alias
   kl_threshold: 0.008
   min_lr: 1e-5                   # ALWAYS set both bounds explicitly:
-  max_lr: 1e-3                   # class defaults (1e-6 / 1e-2) are too wide
+  max_lr: 1e-3                   # = the default ceiling (was 1e-2 before 2.0; still set bounds explicitly per task)
 ```
 
 | Value | LR updates | KL input | When |

--- a/rl_games/common/a2c_common.py
+++ b/rl_games/common/a2c_common.py
@@ -349,7 +349,7 @@ class A2CBase(BaseAlgorithm):
             self.scheduler = schedulers.AdaptiveScheduler(
                 self.kl_threshold,
                 min_lr=config.get('min_lr', 1e-6),
-                max_lr=config.get('max_lr', 1e-2),
+                max_lr=config.get('max_lr', 1e-3),
                 lr_multiplier=config.get('lr_multiplier', 1.5))
 
         elif self.linear_lr:

--- a/rl_games/common/schedulers.py
+++ b/rl_games/common/schedulers.py
@@ -17,7 +17,7 @@ class IdentityScheduler(RLScheduler):
 
 
 class AdaptiveScheduler(RLScheduler):
-    def __init__(self, kl_threshold=0.008, min_lr=1e-6, max_lr=1e-2, lr_multiplier=1.5):
+    def __init__(self, kl_threshold=0.008, min_lr=1e-6, max_lr=1e-3, lr_multiplier=1.5):
         super().__init__()
         self.min_lr = min_lr
         self.max_lr = max_lr

--- a/tests/test_perf_fixes.py
+++ b/tests/test_perf_fixes.py
@@ -215,13 +215,17 @@ class TestSchedulerTunables:
         lr, _ = s.update(6e-4, 0.0, 0, 0, kl_dist=0.03)   # floor respected
         assert lr == pytest.approx(5e-4)
 
-    def test_adaptive_defaults_unchanged(self):
+    def test_adaptive_defaults(self):
         from rl_games.common.schedulers import AdaptiveScheduler
         s = AdaptiveScheduler(kl_threshold=0.008)
         lr, _ = s.update(1e-3, 0.0, 0, 0, kl_dist=0.02)
         assert lr == pytest.approx(1e-3 / 1.5)
+        # raising from 1e-3 saturates at the new default ceiling (1e-3 since
+        # 2.0; the legacy 1e-2 ceiling sat ~10x above healthy KL equilibria)
         lr, _ = s.update(1e-3, 0.0, 0, 0, kl_dist=0.003)
-        assert lr == pytest.approx(1.5e-3)
+        assert lr == pytest.approx(1e-3)
+        lr, _ = s.update(5e-4, 0.0, 0, 0, kl_dist=0.003)
+        assert lr == pytest.approx(7.5e-4)
 
 
 class TestConfigDrivenEnvRegistration:
@@ -282,3 +286,13 @@ class TestStateDependentSigmaInit:
         expected = F.softplus(torch.tensor(-1.0)) + 0.2
         assert torch.allclose(s, expected.expand_as(s), rtol=1e-4), (s.min(), s.max())
 
+
+
+class TestAdaptiveLrDefaultCeiling:
+
+    def test_default_max_lr_is_1e_3(self):
+        # A 1e-2 ceiling lets the KL controller rail an order of magnitude
+        # above healthy locomotion equilibria (measured ~2.5e-4) and amplified
+        # a sigma-explosion feedback on MicroDuck; 1e-3 is the sane default.
+        from rl_games.common.schedulers import AdaptiveScheduler
+        assert AdaptiveScheduler().max_lr == 1e-3


### PR DESCRIPTION
Default-change requested by Viktor: the legacy 1e-2 ceiling is ~10x above the controller's healthy equilibrium on GPU-sim locomotion (measured ~2.5e-4 on MicroDuck; the ceiling was only ever reached under the sigma-explosion pathology it then amplified — see the MicroDuck root-cause writeup). New default 1e-3 in both AdaptiveScheduler and the a2c_common fallback; docs updated; regression test added. Explicit per-task bounds remain recommended. Needs a release-notes row (default change for unset configs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)