### PR TITLE
Frozen-teacher distillation inside PPO (DAgger as a scheduled loss) + Craftax and mujoco_playground vision envs

### DIFF
--- a/docs/DISTILLATION.md
+++ b/docs/DISTILLATION.md
@@ -77,7 +77,51 @@ XLA_PYTHON_CLIENT_MEM_FRACTION=0.3 python scripts/craftax_train.py -f rl_games/c
 python -m pytest tests/test_distillation.py tests/test_craftax_env.py -q
 ```
 
-## Results (2026-09-05, one seed each, 1500 epochs = 98M frames)
+## Robotics vision: Panda pick-cube (mujoco_playground)
+
+`rl_games/envs/playground_vecenv.py` (env name `playground`, JAX + Warp
+physics, mujoco 3.12's built-in batch renderer) exposes any mujoco_playground
+env with `obs: state | pixels | both`; the state vector is the env's own
+`_get_obs(data, info)` from the same physics state the pixels are rendered
+from. `PandaPickCubeCartesian`: 66-d state, 64x64 gripper camera, 3-d
+Cartesian actions, episodes end on success. Configs in
+`rl_games/configs/playground/`, `scripts/playground_train.py`,
+`scripts/playground_play.py`.
+
+Setup notes: playground 0.2 needs mujoco 3.12 + mujoco-warp 3.12 +
+`warp-lang==1.16.0`; under WSL2 the CUDA toolkit's stub libcuda shadows the
+driver, so `LD_LIBRARY_PATH=/usr/lib/wsl/lib` is required (the scripts
+re-exec with it). 1024 worlds train at ~30k frames/s (state) / ~7k (pixels).
+
+Results (one seed each, 300 epochs = 9.8M frames):
+
+| frames (M) | 1 | 2 | 4 | 6 | 8 | 9.8 |
+|---|---|---|---|---|---|---|
+| teacher (state) success | 0.00 | 0.00 | 0.61 | 0.98 | 1.00 | 1.00 |
+| scratch (pixels) success | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| distilled (pixels) success | 0.06 | 0.23 | 1.00 | 1.00 | 1.00 | 1.00 |
+| teacher reward | 2.7 | 4.6 | 8.5 | 10.5 | 10.8 | 10.6 |
+| scratch reward | 1.9 | 1.9 | 1.7 | 2.1 | 4.0 | 3.7 |
+| distilled reward | 3.0 | 4.4 | 10.5 | 10.6 | 10.5 | 10.6 |
+
+The pixel student from scratch never grasps the cube in 9.8M frames; the
+distilled pixel student reaches the teacher's 100% success by 4M frames,
+i.e. as fast as the state teacher itself learned.
+
+What it took (the first attempt failed, `runs/panda_pick_pixels_distill_v1_failed_*`):
+
+- **Fixed learning rate.** The distillation term makes consecutive policies
+  differ by far more than `kl_threshold`, so rl_games' adaptive schedule sank
+  the lr to 5e-6 from epoch 1 and the student barely moved. Use
+  `lr_schedule: fixed` (or linear) with distillation.
+- **Clip the teacher's means.** A continuous teacher's `mu` is unbounded
+  (here ±3 with the env clipping actions at ±1); matching it is an unreachable
+  target that fights the student's bounds loss until the means blow up.
+  `teacher_mu_clip: 1.0` clamps the targets to the action range. With that,
+  `loss: mse` on the means (behaviour cloning of the mean, sigma left to PPO)
+  was the stable choice for continuous actions.
+
+## Results: Craftax-Classic (2026-09-05, one seed each, 1500 epochs = 98M frames)
 
 Teacher: symbolic MLP, 25 min at 106k fps. Students: same CNN, same frames,
 trained side by side on one GPU (scratch 44k fps, distilled 32k fps).

--- a/docs/DISTILLATION.md
+++ b/docs/DISTILLATION.md
@@ -1,0 +1,112 @@
+# Frozen-teacher distillation inside PPO
+
+`rl_games/common/distillation.py` adds a distillation loss to the existing PPO
+agents (`a2c_discrete`, `a2c_continuous`). The teacher is a frozen rl_games
+checkpoint that consumes privileged `states`; the student consumes `obs`.
+Because PPO's on-policy buffer is rebuilt from the student's own rollouts every
+epoch, the loss is DAgger by construction: supervised on the states the student
+visits. Three schedules turn one mechanism into the usual variants:
+
+| variant | `ppo_coef` | `coef` (KL) | `beta` |
+|---|---|---|---|
+| pure DAgger | 0 | 1 | 0.5 -> 0 |
+| DAgger -> PPO fine-tune | 0 then 1 | 1 -> 0 | 0.5 -> 0 |
+| teacher-guided RL | 1 | small constant | 0 |
+
+## Config
+
+```yaml
+config:
+  central_value_config:          # optional; the student's asymmetric critic on states
+    network: {name: actor_critic, central_value: True, mlp: {units: [512, 512, 256], activation: elu}}
+    normalize_input: True
+    ...
+  distillation:
+    teacher_config: rl_games/configs/craftax/ppo_craftax_classic_symbolic.yaml
+    teacher_checkpoint: runs/<teacher run>/nn/craftax_classic_symbolic.pth
+    loss: kl                        # discrete: KL(teacher || student); continuous: kl | mse
+    coef:     [[0, 1.0], [300, 1.0], [600, 0.0]]   # piecewise-linear in epochs
+    ppo_coef: [[0, 0.0], [300, 0.0], [301, 1.0]]
+    beta:     [[0, 0.5], [150, 0.0]]              # P(env action taken from the teacher)
+    warm_start_value: True
+```
+
+What happens inside the agent:
+
+- `states` are stored in the experience buffer and passed into every
+  minibatch whenever the block is present (not only with a central value net).
+- `get_action_values`: with probability `beta` a row's env action is the
+  teacher's sample; the student's `neglogp` is recomputed for those rows so the
+  PPO importance ratios stay valid.
+- `calc_gradients`: `loss = ppo_coef * ppo_loss + coef * KL(teacher || student)`
+  on the minibatch's states; logged as `losses/distill`, with
+  `info/distill_coef`, `info/ppo_coef`, `info/teacher_beta`.
+- Warm start: every teacher tensor whose name and shape match a tensor of the
+  central-value model is copied (trunk, value head, input and value
+  normalisers). The teacher's critic is a privileged-state value function, so
+  the student's central value starts from it instead of from scratch. Use the
+  teacher's MLP as the `central_value_config` network for a full match.
+
+The env must return `{'obs': ..., 'states': ...}` and expose `state_space`
+in `get_env_info()`.
+
+## Vision env: Craftax-Classic
+
+`rl_games/envs/craftax_vecenv.py` (env name `craftax`, JAX, 3.11 venv) renders
+the same Craftax-Classic (Crafter) state as a 1345-d symbolic vector and a
+63x63x3 image: `obs: symbolic | pixels | both`. 1024 envs run at ~90k
+env-steps/s on one GPU; the pixel render adds ~1 ms per batch. Rendered MuJoCo
+was rejected: envpool's renderer costs 7-10 ms per env per frame, serially.
+`CraftaxObserver` (attached by `scripts/craftax_train.py`) logs
+`craftax/score` (Crafter score = geometric mean of achievement rates) and
+`craftax/ach_<name>`.
+
+Configs in `rl_games/configs/craftax/`:
+
+- `ppo_craftax_classic_symbolic.yaml` — teacher, MLP on symbolic states.
+- `ppo_craftax_classic_pixels.yaml` — pixel student from scratch (CNN), baseline.
+- `ppo_craftax_classic_pixels_distill.yaml` — pixel student distilled from the
+  teacher, central value = teacher MLP on states, warm-started.
+
+```bash
+source venv/bin/activate
+python scripts/craftax_train.py -f rl_games/configs/craftax/ppo_craftax_classic_symbolic.yaml
+# edit distillation.teacher_checkpoint, then (both fit on one GPU with JAX prealloc capped)
+XLA_PYTHON_CLIENT_MEM_FRACTION=0.3 python scripts/craftax_train.py -f rl_games/configs/craftax/ppo_craftax_classic_pixels.yaml
+XLA_PYTHON_CLIENT_MEM_FRACTION=0.3 python scripts/craftax_train.py -f rl_games/configs/craftax/ppo_craftax_classic_pixels_distill.yaml
+python -m pytest tests/test_distillation.py tests/test_craftax_env.py -q
+```
+
+## Results (2026-09-05, one seed each, 1500 epochs = 98M frames)
+
+Teacher: symbolic MLP, 25 min at 106k fps. Students: same CNN, same frames,
+trained side by side on one GPU (scratch 44k fps, distilled 32k fps).
+
+| frames (M) | 10 | 20 | 40 | 60 | 80 | 98 |
+|---|---|---|---|---|---|---|
+| teacher (symbolic) reward | 12.2 | 14.0 | 15.4 | 16.2 | 16.6 | 17.0 |
+| scratch (pixels) reward | 11.2 | 13.0 | 14.6 | 15.2 | 15.8 | 16.1 |
+| distilled (pixels) reward | 12.1 | 13.4 | 16.1 | 16.4 | 16.5 | 16.5 |
+| teacher Crafter score | 26 | 34 | 45 | 55 | 58 | 60 |
+| scratch Crafter score | 19 | 30 | 39 | 46 | 53 | 54 |
+| distilled Crafter score | 30 | 34 | 55 | 56 | 56 | 56 |
+
+Achievement rates at 98M frames (teacher / scratch / distilled):
+collect_iron 0.84 / 0.69 / 0.69, make_iron_pickaxe 0.49 / 0.20 / 0.19,
+make_iron_sword 0.40 / 0.42 / 0.48, defeat_skeleton 0.80 / 0.62 / 0.63.
+
+Reading:
+
+- The distilled student reaches the scratch student's *final* level
+  (reward 16.1, score 54) at 40M frames, i.e. ~2.5x fewer frames, and ends
+  slightly higher (16.5 / 56 vs 16.1 / 54). Neither pixel student reaches the
+  teacher (17.0 / 60) in this budget; the gap is in iron-pickaxe rate.
+- Numbers before 20M frames for the distilled run include teacher actions
+  (`beta` 0.5 -> 0 over the first 150 epochs / 10M frames); from 20M on they
+  are the student alone.
+- `losses/distill` (monitoring only after epoch 600) climbs from 0.7 to 2.1
+  once PPO takes over: the fine-tuned student moves away from the teacher's
+  action distribution while keeping its return, which is the point of the
+  fine-tune phase.
+- Single seed each; differences of ~0.4 reward at the end are within what a
+  seed can move. The 40M-frame gap (16.1 vs 14.6, 55 vs 39) is not.

--- a/docs/DISTILLATION.md
+++ b/docs/DISTILLATION.md
@@ -126,8 +126,10 @@ i.e. as fast as the state teacher itself learned.
 (`ppo_panda_pick_pixels_stateaux.yaml`, network `actor_critic_state_aux`:
 same CNN plus an MSE head regressing the running-normalised 66-d state from
 the actor trunk, `state_aux: {}` in the algo config) does not help: the head
-learns the state well (normalised MSE 0.78 -> 0.17) but success stays at 0
-and the reward curve is the scratch student's. On this task the bottleneck is
+learns part of the state (training MSE 0.78 -> 0.17; on fresh rollouts R^2
+0.85 for arm joints, 0.83 gripper position, 0.75 cube-to-gripper offset,
+0.49 target-to-cube offset, but ~0 for cube orientation and velocities) yet
+success stays at 0 and the reward curve is the scratch student's. On this task the bottleneck is
 not the representation but exploration / credit assignment for a grasp that
 random pixel policies never stumble on; the teacher's actions supply exactly
 that, a state-prediction target does not.

--- a/docs/DISTILLATION.md
+++ b/docs/DISTILLATION.md
@@ -99,14 +99,26 @@ Results (one seed each, 300 epochs = 9.8M frames):
 |---|---|---|---|---|---|---|
 | teacher (state) success | 0.00 | 0.00 | 0.61 | 0.98 | 1.00 | 1.00 |
 | scratch (pixels) success | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scratch + state-aux (pixels) success | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
 | distilled (pixels) success | 0.06 | 0.23 | 1.00 | 1.00 | 1.00 | 1.00 |
 | teacher reward | 2.7 | 4.6 | 8.5 | 10.5 | 10.8 | 10.6 |
 | scratch reward | 1.9 | 1.9 | 1.7 | 2.1 | 4.0 | 3.7 |
+| scratch + state-aux reward | 1.9 | 2.3 | 2.3 | 3.8 | 3.9 | 3.9 |
 | distilled reward | 3.0 | 4.4 | 10.5 | 10.6 | 10.5 | 10.6 |
 
 The pixel student from scratch never grasps the cube in 9.8M frames; the
 distilled pixel student reaches the teacher's 100% success by 4M frames,
 i.e. as fast as the state teacher itself learned.
+
+**Privileged state as an auxiliary target instead of a teacher**
+(`ppo_panda_pick_pixels_stateaux.yaml`, network `actor_critic_state_aux`:
+same CNN plus an MSE head regressing the running-normalised 66-d state from
+the actor trunk, `state_aux: {}` in the algo config) does not help: the head
+learns the state well (normalised MSE 0.78 -> 0.17) but success stays at 0
+and the reward curve is the scratch student's. On this task the bottleneck is
+not the representation but exploration / credit assignment for a grasp that
+random pixel policies never stumble on; the teacher's actions supply exactly
+that, a state-prediction target does not.
 
 What it took (the first attempt failed, `runs/panda_pick_pixels_distill_v1_failed_*`):
 

--- a/docs/DISTILLATION.md
+++ b/docs/DISTILLATION.md
@@ -95,16 +95,28 @@ re-exec with it). 1024 worlds train at ~30k frames/s (state) / ~7k (pixels).
 
 Results (one seed each, 300 epochs = 9.8M frames):
 
+Success rate (fraction of episodes with the cube at the target):
+
 | frames (M) | 1 | 2 | 4 | 6 | 8 | 9.8 |
 |---|---|---|---|---|---|---|
-| teacher (state) success | 0.00 | 0.00 | 0.61 | 0.98 | 1.00 | 1.00 |
-| scratch (pixels) success | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
-| scratch + state-aux (pixels) success | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
-| distilled (pixels) success | 0.06 | 0.23 | 1.00 | 1.00 | 1.00 | 1.00 |
-| teacher reward | 2.7 | 4.6 | 8.5 | 10.5 | 10.8 | 10.6 |
-| scratch reward | 1.9 | 1.9 | 1.7 | 2.1 | 4.0 | 3.7 |
-| scratch + state-aux reward | 1.9 | 2.3 | 2.3 | 3.8 | 3.9 | 3.9 |
-| distilled reward | 3.0 | 4.4 | 10.5 | 10.6 | 10.5 | 10.6 |
+| scratch (pixels) | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| scratch + state-aux (pixels) | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 | 0.00 |
+| distilled (pixels) | 0.06 | 0.23 | 1.00 | 1.00 | 1.00 | 1.00 |
+| teacher (state) | 0.00 | 0.00 | 0.61 | 0.98 | 1.00 | 1.00 |
+
+Episode reward (shaped: gripper-to-box 4, box-to-target 8, lifted 0.5,
+success 2, collisions 0.3; the env pays out increases only, so this is the
+best progress reached in the episode):
+
+| frames (M) | 1 | 2 | 4 | 6 | 8 | 9.8 |
+|---|---|---|---|---|---|---|
+| scratch (pixels) | 1.9 | 1.9 | 1.7 | 2.1 | 4.0 | 3.7 |
+| scratch + state-aux (pixels) | 1.9 | 2.3 | 2.3 | 3.8 | 3.9 | 3.9 |
+| distilled (pixels) | 3.0 | 4.4 | 10.5 | 10.6 | 10.5 | 10.6 |
+| teacher (state) | 2.7 | 4.6 | 8.5 | 10.5 | 10.8 | 10.6 |
+
+A reward near 4 with success 0 means the gripper reaches the cube (the
+4-point term) but never carries it (the 8-point term).
 
 The pixel student from scratch never grasps the cube in 9.8M frames; the
 distilled pixel student reaches the teacher's 100% success by 4M frames,

--- a/docs/superpowers/plans/2026-09-05-teacher-distillation.md
+++ b/docs/superpowers/plans/2026-09-05-teacher-distillation.md
@@ -1,0 +1,886 @@
+# Teacher Distillation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A frozen-teacher distillation loss inside rl_games PPO with weight schedules (DAgger / DAgger→PPO / teacher-guided RL as config variants), applied to a Craftax-Classic pixel student with a symbolic-state teacher.
+
+**Architecture:** `TeacherDistillation` (pure torch helper) owns the frozen teacher, the three schedules, the KL/MSE loss, DAgger action mixing and the central-value warm start; the PPO agents call it from `get_action_values` and `calc_gradients`. `CraftaxVecEnv` steps Craftax-Classic in JAX and returns `{'obs': pixels, 'states': symbolic}` torch tensors via dlpack.
+
+**Tech Stack:** PyTorch, rl_games `a2c_discrete`/`a2c_continuous`, JAX + craftax 1.6 (`venv/`, python 3.11, `jax[cuda12]`), pytest.
+
+**Spec:** `docs/superpowers/specs/2026-09-05-teacher-distillation-design.md`
+
+## Global Constraints
+
+- Craftax lives in the 3.11 venv: run its tests and training with `venv/bin/python`. Distillation unit tests are pure torch and run in either venv.
+- Observation dict convention: `{'obs': student input, 'states': teacher / central-value input}`; `get_env_info` returns `observation_space` (obs) and `state_space` (states).
+- Schedules are `[[epoch, value], ...]` lists, piecewise-linear, constant outside the range.
+- Commit trailer as used on this branch.
+
+---
+
+### Task 1: `TeacherDistillation` core (schedules, losses, mixing, warm start)
+
+**Files:**
+- Create: `rl_games/common/distillation.py`
+- Test: `tests/test_distillation.py`
+
+**Interfaces:**
+- Produces: `piecewise_linear(spec, epoch) -> float`; class `TeacherDistillation(config, teacher_model, is_discrete, device)` with `coef(epoch)`, `ppo_coef(epoch)`, `beta(epoch)`, `loss(res_dict, states, rnn_masks=None) -> tensor`, `mix_actions(res_dict, states, epoch) -> res_dict`, `warm_start_central_value(cv_model) -> (copied, skipped)`, classmethod `from_config(config, state_shape, actions_num, device)` building the teacher from `teacher_config` + `teacher_checkpoint`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/test_distillation.py
+import numpy as np
+import pytest
+import torch
+
+
+def test_piecewise_linear_schedule():
+    from rl_games.common.distillation import piecewise_linear
+    spec = [[0, 1.0], [10, 1.0], [20, 0.0]]
+    assert piecewise_linear(spec, -5) == 1.0
+    assert piecewise_linear(spec, 5) == 1.0
+    assert abs(piecewise_linear(spec, 15) - 0.5) < 1e-9
+    assert piecewise_linear(spec, 30) == 0.0
+    assert piecewise_linear(0.3, 7) == 0.3            # scalar spec = constant
+    assert piecewise_linear(None, 7) == 0.0
+
+
+class _Teacher(torch.nn.Module):
+    """Stand-in teacher: logits = W states (discrete) or mus = W states (continuous)."""
+
+    def __init__(self, in_dim, out_dim, discrete=True, seed=0):
+        super().__init__()
+        torch.manual_seed(seed)
+        self.lin = torch.nn.Linear(in_dim, out_dim)
+        self.discrete = discrete
+
+    def forward(self, d):
+        h = self.lin(d['obs'])
+        if self.discrete:
+            return {'logits': h}
+        return {'mus': h, 'sigmas': torch.full_like(h, 0.5)}
+
+
+def _distill(teacher, discrete, **cfg):
+    from rl_games.common.distillation import TeacherDistillation
+    base = {'coef': 1.0, 'ppo_coef': 1.0, 'beta': 0.0, 'loss': 'kl'}
+    base.update(cfg)
+    return TeacherDistillation(base, teacher, is_discrete=discrete, device='cpu')
+
+
+def test_discrete_kl_matches_manual_and_is_zero_for_identical():
+    t = _Teacher(4, 5)
+    d = _distill(t, True)
+    states = torch.randn(16, 4)
+    student_logits = torch.randn(16, 5)
+    with torch.no_grad():
+        p = torch.softmax(t.lin(states), -1)
+    manual = (p * (torch.log(p) - torch.log_softmax(student_logits, -1))).sum(-1).mean()
+    got = d.loss({'logits': student_logits}, states)
+    assert torch.allclose(got, manual, atol=1e-6)
+    with torch.no_grad():
+        same = d.loss({'logits': t.lin(states)}, states)
+    assert same.abs() < 1e-6
+    masks = torch.zeros(16, 1); masks[:4] = 1
+    masked = d.loss({'logits': student_logits}, states, rnn_masks=masks)
+    manual_m = (p * (torch.log(p) - torch.log_softmax(student_logits, -1))).sum(-1)[:4].mean()
+    assert torch.allclose(masked, manual_m, atol=1e-6)
+
+
+def test_gaussian_kl_and_mse():
+    t = _Teacher(4, 3, discrete=False)
+    states = torch.randn(8, 4)
+    mus = torch.randn(8, 3); sig = torch.full((8, 3), 0.8)
+    with torch.no_grad():
+        tm = t.lin(states); ts = torch.full_like(tm, 0.5)
+    kl = (torch.log(sig / ts) + (ts ** 2 + (tm - mus) ** 2) / (2 * sig ** 2) - 0.5).sum(-1).mean()
+    assert torch.allclose(_distill(t, False).loss({'mus': mus, 'sigmas': sig}, states), kl, atol=1e-6)
+    mse = ((tm - mus) ** 2).sum(-1).mean()
+    assert torch.allclose(_distill(t, False, loss='mse').loss({'mus': mus, 'sigmas': sig}, states), mse, atol=1e-6)
+
+
+def test_mix_actions_substitutes_beta_rows_with_valid_neglogp():
+    torch.manual_seed(1)
+    t = _Teacher(4, 5)
+    d = _distill(t, True, beta=[[0, 1.0], [10, 0.0]])
+    N = 2000
+    states = torch.randn(N, 4)
+    logits = torch.randn(N, 5)
+    dist = torch.distributions.Categorical(logits=logits)
+    actions = dist.sample()
+    res = {'logits': logits, 'actions': actions.clone(), 'neglogpacs': -dist.log_prob(actions)}
+    out = d.mix_actions(res, states, epoch=5)                       # beta 0.5
+    changed = (out['actions'] != actions).float().mean().item()
+    assert 0.25 < changed < 0.55                                     # ~half the rows re-drawn from the teacher
+    assert torch.allclose(out['neglogpacs'], -dist.log_prob(out['actions']), atol=1e-5)
+    untouched = d.mix_actions(dict(res), states, epoch=20)           # beta 0
+    assert torch.equal(untouched['actions'], actions)
+    # continuous: substituted rows carry the student's Gaussian neglogp
+    tc = _Teacher(4, 3, discrete=False)
+    dc = _distill(tc, False, beta=1.0)
+    mus = torch.randn(N, 3); sig = torch.full((N, 3), 0.7)
+    resc = {'mus': mus, 'sigmas': sig, 'actions': mus.clone(), 'neglogpacs': torch.zeros(N)}
+    outc = dc.mix_actions(resc, states, epoch=0)
+    ref = -torch.distributions.Normal(mus, sig).log_prob(outc['actions']).sum(-1)
+    assert torch.allclose(outc['neglogpacs'], ref, atol=1e-4)
+    assert not torch.allclose(outc['actions'], mus)
+
+
+def test_warm_start_copies_matching_tensors_only():
+    teacher = torch.nn.ModuleDict({'trunk': torch.nn.Linear(4, 8), 'value': torch.nn.Linear(8, 1),
+                                   'logits': torch.nn.Linear(8, 5)})
+    cv = torch.nn.ModuleDict({'trunk': torch.nn.Linear(4, 8), 'value': torch.nn.Linear(8, 1),
+                              'extra': torch.nn.Linear(2, 2)})
+    d = _distill(teacher, True)
+    copied, skipped = d.warm_start_central_value(cv)
+    assert copied == 4 and skipped == 2                           # extra.* skipped
+    assert torch.equal(cv['trunk'].weight, teacher['trunk'].weight)
+    assert torch.equal(cv['value'].bias, teacher['value'].bias)
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `venv312/bin/python -m pytest tests/test_distillation.py -q`
+Expected: FAIL, `ModuleNotFoundError: rl_games.common.distillation`
+
+- [ ] **Step 3: Implement**
+
+```python
+# rl_games/common/distillation.py
+"""Frozen-teacher distillation inside PPO (DAgger as a loss term).
+
+The teacher is a frozen rl_games policy that consumes privileged `states`;
+the student consumes `obs`. Three piecewise-linear schedules over epochs:
+
+  coef      weight of the distillation loss on student-visited states
+  ppo_coef  weight of the PPO loss (0 -> pure DAgger phase)
+  beta      P(env action taken from the teacher) — classic DAgger mixing;
+            the student's neglogp is recomputed for substituted rows so PPO
+            importance ratios stay valid.
+
+Config (algo `config.distillation`):
+
+    distillation:
+      teacher_config: <yaml with the teacher's params>
+      teacher_checkpoint: <rl_games .pth>
+      loss: kl                 # discrete: KL(teacher||student); continuous: kl | mse
+      coef: [[0, 1.0], [400, 1.0], [800, 0.0]]
+      ppo_coef: [[0, 0.0], [400, 0.0], [401, 1.0]]
+      beta: [[0, 0.5], [200, 0.0]]
+      warm_start_value: True   # copy matching teacher tensors into the central value net
+"""
+
+import copy
+
+import numpy as np
+import torch
+import yaml
+
+
+def piecewise_linear(spec, epoch):
+    """[[epoch, value], ...] -> value at `epoch` (linear between knots,
+    constant outside). A scalar spec is a constant; None is 0."""
+    if spec is None:
+        return 0.0
+    if isinstance(spec, (int, float)):
+        return float(spec)
+    knots = sorted((float(e), float(v)) for e, v in spec)
+    if epoch <= knots[0][0]:
+        return knots[0][1]
+    for (e0, v0), (e1, v1) in zip(knots[:-1], knots[1:]):
+        if e0 <= epoch <= e1:
+            if e1 == e0:
+                return v1
+            return v0 + (v1 - v0) * (epoch - e0) / (e1 - e0)
+    return knots[-1][1]
+
+
+def _strip_prefix(sd, prefix='_orig_mod.'):
+    return {k[len(prefix):] if k.startswith(prefix) else k: v for k, v in sd.items()}
+
+
+class TeacherDistillation:
+    def __init__(self, config, teacher_model, is_discrete, device):
+        self.config = config
+        self.teacher = teacher_model.to(device).eval()
+        for p in self.teacher.parameters():
+            p.requires_grad_(False)
+        self.is_discrete = is_discrete
+        self.device = device
+        self.loss_type = config.get('loss', 'kl')
+        if self.loss_type not in ('kl', 'mse'):
+            raise ValueError("distillation loss must be 'kl' or 'mse'")
+        self._coef = config.get('coef', 1.0)
+        self._ppo_coef = config.get('ppo_coef', 1.0)
+        self._beta = config.get('beta', 0.0)
+        self.warm_start_value = bool(config.get('warm_start_value', True))
+        self.last_loss = None
+
+    # ----------------------------------------------------------- schedules
+
+    def coef(self, epoch):
+        return piecewise_linear(self._coef, epoch)
+
+    def ppo_coef(self, epoch):
+        return piecewise_linear(self._ppo_coef, epoch)
+
+    def beta(self, epoch):
+        return piecewise_linear(self._beta, epoch)
+
+    # ------------------------------------------------------------- teacher
+
+    @torch.no_grad()
+    def teacher_forward(self, states):
+        return self.teacher({'obs': states, 'is_train': False})
+
+    @classmethod
+    def from_config(cls, config, state_shape, actions_num, device):
+        """Build the frozen teacher from its own yaml + checkpoint."""
+        from rl_games.algos_torch.model_builder import ModelBuilder
+        params = yaml.safe_load(open(config['teacher_config']))['params']
+        net = ModelBuilder().load(params)
+        tcfg = params['config']
+        model = net.build({'actions_num': actions_num, 'input_shape': tuple(state_shape), 'num_seqs': 1,
+                           'value_size': tcfg.get('value_size', 1),
+                           'normalize_value': tcfg.get('normalize_value', False),
+                           'normalize_input': tcfg.get('normalize_input', False)})
+        ckpt = torch.load(config['teacher_checkpoint'], map_location=device, weights_only=False)
+        model.load_state_dict(_strip_prefix(ckpt['model']))
+        is_discrete = params['algo']['name'] == 'a2c_discrete'
+        print(f"[Distillation] teacher {config['teacher_checkpoint']} (epoch {ckpt.get('epoch', '?')}), "
+              f"{'discrete' if is_discrete else 'continuous'}, coef {config.get('coef')}, "
+              f"ppo_coef {config.get('ppo_coef')}, beta {config.get('beta')}")
+        return cls(config, model, is_discrete, device)
+
+    # ---------------------------------------------------------------- loss
+
+    def loss(self, res_dict, states, rnn_masks=None):
+        """Mean distillation loss over rows (masked when rnn_masks given)."""
+        t = self.teacher_forward(states)
+        if self.is_discrete:
+            logp_t = torch.log_softmax(t['logits'].float(), dim=-1)
+            logp_s = torch.log_softmax(res_dict['logits'].float(), dim=-1)
+            per_row = (logp_t.exp() * (logp_t - logp_s)).sum(dim=-1)
+        else:
+            mu_s, sig_s = res_dict['mus'].float(), res_dict['sigmas'].float()
+            mu_t, sig_t = t['mus'].float(), t['sigmas'].float()
+            if self.loss_type == 'mse':
+                per_row = ((mu_t - mu_s) ** 2).sum(dim=-1)
+            else:
+                per_row = (torch.log(sig_s / sig_t) + (sig_t ** 2 + (mu_t - mu_s) ** 2) / (2 * sig_s ** 2) - 0.5).sum(dim=-1)
+        if rnn_masks is not None:
+            m = rnn_masks.reshape(-1).float()
+            out = (per_row * m).sum() / m.sum().clamp(min=1.0)
+        else:
+            out = per_row.mean()
+        self.last_loss = out.detach()
+        return out
+
+    # ------------------------------------------------------------- mixing
+
+    def mix_actions(self, res_dict, states, epoch):
+        """DAgger beta-mixing on the rollout batch: substitute the teacher's
+        sampled action for a Bernoulli(beta) subset of rows and recompute the
+        student's neglogp for those rows."""
+        beta = self.beta(epoch)
+        if beta <= 0.0:
+            return res_dict
+        n = states.shape[0]
+        sel = torch.rand(n, device=states.device) < beta
+        if not sel.any():
+            return res_dict
+        t = self.teacher_forward(states[sel])
+        actions = res_dict['actions'].clone()
+        if self.is_discrete:
+            ta = torch.distributions.Categorical(logits=t['logits'].float()).sample()
+            actions[sel] = ta.to(actions.dtype)
+            neglogp = -torch.log_softmax(res_dict['logits'].float(), dim=-1).gather(1, actions.view(-1, 1).long()).squeeze(1)
+        else:
+            ta = torch.distributions.Normal(t['mus'].float(), t['sigmas'].float()).sample()
+            actions[sel] = ta.to(actions.dtype)
+            mus, sig = res_dict['mus'].float(), res_dict['sigmas'].float()
+            neglogp = 0.5 * (((actions.float() - mus) / sig) ** 2).sum(-1) \
+                + 0.5 * np.log(2.0 * np.pi) * actions.shape[-1] + torch.log(sig).sum(-1)
+        res_dict['actions'] = actions
+        res_dict['neglogpacs'] = neglogp.to(res_dict['neglogpacs'].dtype)
+        return res_dict
+
+    # ---------------------------------------------------------- warm start
+
+    def warm_start_central_value(self, cv_model):
+        """Copy every teacher tensor whose name and shape match into the
+        central-value model (trunk, value head, input/value normalisers)."""
+        tsd = _strip_prefix(self.teacher.state_dict())
+        csd = cv_model.state_dict()
+        new, copied, skipped = {}, 0, 0
+        for k, v in csd.items():
+            if k in tsd and tuple(tsd[k].shape) == tuple(v.shape):
+                new[k] = tsd[k].to(v.device, v.dtype)
+                copied += 1
+            else:
+                skipped += 1
+        cv_model.load_state_dict(new, strict=False)
+        print(f'[Distillation] warm-started central value: {copied} tensors copied, {skipped} skipped')
+        return copied, skipped
+
+    # ------------------------------------------------------------- logging
+
+    def log(self, writer, epoch, frame):
+        if writer is None:
+            return
+        writer.add_scalar('info/distill_coef', self.coef(epoch), frame)
+        writer.add_scalar('info/ppo_coef', self.ppo_coef(epoch), frame)
+        writer.add_scalar('info/teacher_beta', self.beta(epoch), frame)
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Run: `venv312/bin/python -m pytest tests/test_distillation.py -q`
+Expected: 5 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rl_games/common/distillation.py tests/test_distillation.py
+git commit -m "TeacherDistillation: schedules, KL/MSE loss, DAgger mixing, central-value warm start"
+```
+
+---
+
+### Task 2: Craftax vec env + observer
+
+**Files:**
+- Create: `rl_games/envs/craftax_vecenv.py`
+- Modify: `rl_games/common/vecenv.py` (register `CRAFTAX`), `rl_games/common/env_configurations.py` (env `craftax`)
+- Test: `tests/test_craftax_env.py`
+
+**Interfaces:**
+- Produces: `CraftaxVecEnv(config_name, num_actors, game='Craftax-Classic-v1', obs='both', seed=0, device='cuda')`; `reset() -> obs`, `step(actions) -> (obs, rewards, dones, infos)` with torch tensors on `device`; `obs` is a dict `{'obs', 'states'}` for `obs='both'`, a tensor otherwise; `get_env_info()` with `observation_space`, `state_space` (both modes), `action_space` Discrete(17), `agents` 1; infos on any done: `achievements` (N, 22) float, `done_mask` (N,) bool. `CraftaxObserver` (same file) logs `craftax/score` and `craftax/ach_<name>`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/test_craftax_env.py
+import numpy as np
+import pytest
+import torch
+
+
+def _has_craftax():
+    try:
+        import craftax, jax  # noqa
+        return True
+    except Exception:
+        return False
+
+
+needs_craftax = pytest.mark.skipif(not _has_craftax(), reason='craftax/jax unavailable')
+
+
+def _make(n=8, **kw):
+    from rl_games.envs.craftax_vecenv import CraftaxVecEnv
+    cfg = dict(game='Craftax-Classic-v1', obs='both', seed=1, device='cpu')
+    cfg.update(kw)
+    return CraftaxVecEnv('craftax', n, **cfg)
+
+
+@needs_craftax
+def test_both_mode_shapes_and_env_info():
+    env = _make(8)
+    info = env.get_env_info()
+    assert info['observation_space'].shape == (63, 63, 3) and info['observation_space'].dtype == np.uint8
+    assert info['state_space'].shape == (1345,)
+    assert info['action_space'].n == 17 and info['agents'] == 1
+    obs = env.reset()
+    assert obs['obs'].shape == (8, 63, 63, 3) and obs['obs'].dtype == torch.uint8
+    assert obs['states'].shape == (8, 1345) and obs['states'].dtype == torch.float32
+    assert int(obs['obs'].max()) > 0
+    o, r, d, inf = env.step(torch.randint(0, 17, (8,)))
+    assert o['obs'].shape == (8, 63, 63, 3) and r.shape == (8,) and d.shape == (8,) and d.dtype == torch.bool
+    assert r.dtype == torch.float32
+
+
+@needs_craftax
+def test_single_modes():
+    env = _make(4, obs='symbolic')
+    assert env.get_env_info()['observation_space'].shape == (1345,)
+    o = env.reset()
+    assert torch.is_tensor(o) and o.shape == (4, 1345)
+    env = _make(4, obs='pixels')
+    assert env.get_env_info()['observation_space'].shape == (63, 63, 3)
+    o = env.reset()
+    assert torch.is_tensor(o) and o.shape == (4, 63, 63, 3) and o.dtype == torch.uint8
+
+
+@needs_craftax
+def test_autoreset_and_achievements_info():
+    env = _make(4, max_timesteps=30)          # short episodes -> dones within 30 steps
+    env.reset()
+    seen = False
+    for t in range(40):
+        o, r, d, info = env.step(torch.randint(0, 17, (4,)))
+        assert o['obs'].shape == (4, 63, 63, 3)
+        if d.any():
+            seen = True
+            assert info['achievements'].shape == (4, 22)
+            assert torch.equal(info['done_mask'], d)
+    assert seen
+
+
+def test_craftax_observer_score():
+    from rl_games.envs.craftax_vecenv import CraftaxObserver, crafter_score
+    rates = np.zeros(22); rates[:2] = 1.0            # two achievements always, rest never
+    expected = np.exp(np.mean(np.log(1 + rates * 100))) - 1
+    assert abs(crafter_score(rates) - expected) < 1e-9
+
+    class _Algo:
+        writer = None
+        num_agents = 1
+    obs = CraftaxObserver()
+    obs.after_init(_Algo())
+    ach = torch.zeros(4, 22); ach[0, 3] = 1; ach[1, 3] = 1
+    obs.process_infos({'achievements': ach, 'done_mask': torch.tensor([True, True, False, False])}, torch.tensor([[0], [1]]))
+    assert len(obs.episodes) == 2 and abs(obs.rates()[3] - 1.0) < 1e-9 and obs.rates()[0] == 0.0
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `venv/bin/python -m pytest tests/test_craftax_env.py -q`
+Expected: 4 failed, `ModuleNotFoundError: rl_games.envs.craftax_vecenv`
+
+- [ ] **Step 3: Implement**
+
+```python
+# rl_games/envs/craftax_vecenv.py
+"""Craftax (Crafter in JAX) for rl_games, with privileged symbolic states.
+
+Craftax renders one game state two ways: a 1345-d symbolic vector and a
+63x63x3 pixel image (Craftax-Classic). This env returns
+
+  obs: symbolic  -> float32 (N, 1345)
+  obs: pixels    -> uint8   (N, 63, 63, 3)
+  obs: both      -> {'obs': uint8 pixels, 'states': float32 symbolic}
+
+so a symbolic teacher and a pixel student see the same states (see
+rl_games/common/distillation.py). Steps run under jax.jit with craftax's
+auto-reset (same-step: the obs returned on done is the new episode's first
+obs); tensors reach torch via dlpack. ~90k env-steps/s for 1024 envs on GPU.
+
+Infos on any done: `achievements` (N, 22) float32 of the finished episodes
+(rows of unfinished envs are stale and must be masked with `done_mask`).
+CraftaxObserver logs achievement rates and the Crafter score.
+"""
+
+import gymnasium as gym
+import numpy as np
+import torch
+
+from rl_games.common.algo_observer import AlgoObserver
+from rl_games.common.ivecenv import IVecEnv
+
+ACHIEVEMENTS = [
+    'collect_coal', 'collect_diamond', 'collect_drink', 'collect_iron', 'collect_sapling', 'collect_stone',
+    'collect_wood', 'defeat_skeleton', 'defeat_zombie', 'eat_cow', 'eat_plant', 'make_iron_pickaxe',
+    'make_iron_sword', 'make_stone_pickaxe', 'make_stone_sword', 'make_wood_pickaxe', 'make_wood_sword',
+    'place_furnace', 'place_plant', 'place_stone', 'place_table', 'wake_up',
+]
+
+
+def crafter_score(rates):
+    """Crafter score: geometric mean of achievement success rates (in %)."""
+    rates = np.asarray(rates, dtype=np.float64)
+    return float(np.exp(np.mean(np.log(1.0 + rates * 100.0))) - 1.0)
+
+
+class CraftaxVecEnv(IVecEnv):
+    def __init__(self, config_name, num_actors, **kwargs):
+        import jax
+        import jax.numpy as jnp
+        from craftax.craftax_env import make_craftax_env_from_name
+
+        self.num_envs = int(num_actors)
+        self.game = kwargs.pop('game', 'Craftax-Classic-v1')
+        self.obs_mode = kwargs.pop('obs', 'both')
+        if self.obs_mode not in ('symbolic', 'pixels', 'both'):
+            raise ValueError(f'obs must be symbolic | pixels | both, got {self.obs_mode!r}')
+        self.device = kwargs.pop('device', 'cuda' if torch.cuda.is_available() else 'cpu')
+        seed = int(kwargs.pop('seed', 0))
+        if self.game != 'Craftax-Classic-v1':
+            raise NotImplementedError('only Craftax-Classic-v1 is wired up (pixel renderer + 1345-d symbolic)')
+        from craftax.craftax_classic.constants import BLOCK_PIXEL_SIZE_AGENT
+        from craftax.craftax_classic.renderer import make_craftax_pixel_renderer, render_craftax_symbolic
+
+        self._jax, self._jnp = jax, jnp
+        env = make_craftax_env_from_name('Craftax-Classic-Symbolic-v1', auto_reset=True)
+        params = env.default_params
+        if 'max_timesteps' in kwargs:
+            params = params.replace(max_timesteps=int(kwargs.pop('max_timesteps')))
+        self.params = params
+        self.env = env
+        self.actions_num = env.action_space(params).n
+        render_pixels = make_craftax_pixel_renderer(BLOCK_PIXEL_SIZE_AGENT)
+        want_pix = self.obs_mode in ('pixels', 'both')
+        want_sym = self.obs_mode in ('symbolic', 'both')
+        ach_keys = ['Achievements/' + a for a in ACHIEVEMENTS]
+
+        def _outputs(state):
+            pix = render_pixels(state).astype(jnp.uint8) if want_pix else None
+            sym = render_craftax_symbolic(state) if want_sym else None
+            return pix, sym
+
+        def _reset(key):
+            keys = jax.random.split(key, self.num_envs)
+            _, state = jax.vmap(env.reset, in_axes=(0, None))(keys, params)
+            pix, sym = jax.vmap(_outputs)(state)
+            return state, pix, sym
+
+        def _step(key, state, actions):
+            keys = jax.random.split(key, self.num_envs)
+            _, state, reward, done, info = jax.vmap(env.step, in_axes=(0, 0, 0, None))(keys, state, actions, params)
+            pix, sym = jax.vmap(_outputs)(state)
+            ach = jnp.stack([info[k] for k in ach_keys], axis=1).astype(jnp.float32)
+            return state, pix, sym, reward.astype(jnp.float32), done, ach
+
+        self._reset_fn = jax.jit(_reset)
+        self._step_fn = jax.jit(_step)
+        self._key = jax.random.PRNGKey(seed)
+        self._state = None
+        self._dlpack_ok = True
+
+        self.pixel_space = gym.spaces.Box(0, 255, shape=(63, 63, 3), dtype=np.uint8)
+        self.state_space = gym.spaces.Box(-np.inf, np.inf, shape=(1345,), dtype=np.float32)
+        self.observation_space = self.pixel_space if want_pix else self.state_space
+        self.action_space = gym.spaces.Discrete(self.actions_num)
+
+    # ------------------------------------------------------------ bridging
+
+    def _to_torch(self, x):
+        if x is None:
+            return None
+        if self._dlpack_ok:
+            try:
+                return torch.from_dlpack(x).to(self.device)
+            except Exception:
+                self._dlpack_ok = False
+        return torch.as_tensor(np.asarray(x)).to(self.device)
+
+    def _to_jax(self, t):
+        t = t.detach().to(torch.int32).contiguous()
+        try:
+            return self._jax.dlpack.from_dlpack(t)
+        except Exception:
+            return self._jnp.asarray(t.cpu().numpy())
+
+    def _pack(self, pix, sym):
+        if self.obs_mode == 'both':
+            return {'obs': self._to_torch(pix), 'states': self._to_torch(sym)}
+        return self._to_torch(pix if self.obs_mode == 'pixels' else sym)
+
+    def _next_key(self):
+        self._key, sub = self._jax.random.split(self._key)
+        return sub
+
+    # ------------------------------------------------------------- IVecEnv
+
+    def reset(self):
+        self._state, pix, sym = self._reset_fn(self._next_key())
+        return self._pack(pix, sym)
+
+    def step(self, actions):
+        if not torch.is_tensor(actions):
+            actions = torch.as_tensor(np.asarray(actions))
+        acts = self._to_jax(actions.reshape(self.num_envs))
+        self._state, pix, sym, reward, done, ach = self._step_fn(self._next_key(), self._state, acts)
+        rewards = self._to_torch(reward)
+        dones = self._to_torch(done).bool()
+        infos = {}
+        if bool(dones.any()):
+            infos['achievements'] = self._to_torch(ach)
+            infos['done_mask'] = dones
+        return self._pack(pix, sym), rewards, dones, infos
+
+    def get_number_of_agents(self):
+        return 1
+
+    def get_env_info(self):
+        return {'observation_space': self.observation_space, 'state_space': self.state_space,
+                'action_space': self.action_space, 'agents': 1, 'value_size': 1}
+
+
+class CraftaxObserver(AlgoObserver):
+    """Logs craftax/score (Crafter score) and craftax/ach_<name> success rates
+    over the last `window` finished episodes."""
+
+    def __init__(self, window=1000):
+        super().__init__()
+        self.window = window
+        self.episodes = []
+        self.writer = None
+
+    def after_init(self, algo):
+        self.algo = algo
+        self.writer = getattr(algo, 'writer', None)
+
+    def process_infos(self, infos, done_indices):
+        if not isinstance(infos, dict) or 'achievements' not in infos:
+            return
+        ach = infos['achievements'][infos['done_mask']].cpu().numpy()
+        self.episodes.extend(list(ach))
+        self.episodes = self.episodes[-self.window:]
+
+    def rates(self):
+        return np.mean(np.stack(self.episodes), axis=0) if self.episodes else np.zeros(len(ACHIEVEMENTS))
+
+    def after_print_stats(self, frame, epoch_num, total_time):
+        if self.writer is None or not self.episodes:
+            return
+        r = self.rates()
+        self.writer.add_scalar('craftax/score', crafter_score(r), frame)
+        self.writer.add_scalar('craftax/episodes_in_window', len(self.episodes), frame)
+        for name, v in zip(ACHIEVEMENTS, r):
+            self.writer.add_scalar(f'craftax/ach_{name}', float(v), frame)
+
+
+def create_craftax(**kwargs):
+    return CraftaxVecEnv(kwargs.pop('config_name', 'craftax'), kwargs.pop('num_actors', 1024), **kwargs)
+```
+
+`rl_games/common/vecenv.py` (append):
+
+```python
+def _create_craftax(config_name, num_actors, **kwargs):
+    from rl_games.envs.craftax_vecenv import CraftaxVecEnv
+    return CraftaxVecEnv(config_name, num_actors, **kwargs)
+register('CRAFTAX', _create_craftax)
+```
+
+`rl_games/common/env_configurations.py` (in `configurations`):
+
+```python
+    'craftax' : {
+        'vecenv_type': 'CRAFTAX'
+    },
+```
+
+- [ ] **Step 4: Run to verify**
+
+Run: `venv/bin/python -m pytest tests/test_craftax_env.py -q`
+Expected: 4 passed
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rl_games/envs/craftax_vecenv.py rl_games/common/vecenv.py rl_games/common/env_configurations.py tests/test_craftax_env.py
+git commit -m "CraftaxVecEnv: Craftax-Classic with symbolic states + pixel obs, CraftaxObserver"
+```
+
+---
+
+### Task 3: Agent hooks (states plumbing, mixing, loss) + integration test
+
+**Files:**
+- Modify: `rl_games/common/a2c_common.py`, `rl_games/common/experience.py`, `rl_games/algos_torch/a2c_discrete.py`, `rl_games/algos_torch/a2c_continuous.py`
+- Test: `tests/test_craftax_env.py` (append integration test)
+
+**Interfaces:**
+- Consumes: `TeacherDistillation.from_config`, `mix_actions`, `loss`, `coef`, `ppo_coef`, `warm_start_central_value`, `log`.
+- Produces: agent attributes `self.distill`, `self.store_states`; dataset key `states`; tensorboard `losses/distill`, `info/distill_coef`, `info/ppo_coef`, `info/teacher_beta`.
+
+- [ ] **Step 1: Write the failing integration test**
+
+```python
+# append to tests/test_craftax_env.py
+
+@needs_craftax
+def test_distillation_end_to_end_two_epochs(tmp_path):
+    """Symbolic teacher (untrained, saved to disk) -> pixel student with the
+    distillation block; two PPO epochs must run and log losses/distill."""
+    import yaml
+    from rl_games.torch_runner import Runner
+    from rl_games.algos_torch.model_builder import ModelBuilder
+    tcfg = yaml.safe_load(open('rl_games/configs/craftax/ppo_craftax_classic_symbolic.yaml'))
+    net = ModelBuilder().load(tcfg['params'])
+    c = tcfg['params']['config']
+    teacher = net.build({'actions_num': 17, 'input_shape': (1345,), 'num_seqs': 1, 'value_size': 1,
+                         'normalize_value': c['normalize_value'], 'normalize_input': c['normalize_input']})
+    ck = tmp_path / 'teacher.pth'
+    torch.save({'model': teacher.state_dict(), 'epoch': 0}, ck)
+    scfg = yaml.safe_load(open('rl_games/configs/craftax/ppo_craftax_classic_pixels_distill.yaml'))
+    sc = scfg['params']['config']
+    sc.update(num_actors=16, horizon_length=8, minibatch_size=64, max_epochs=2, save_frequency=0,
+              train_dir=str(tmp_path), name='distill_smoke', device='cpu')
+    sc['central_value_config']['minibatch_size'] = 64
+    sc['distillation'].update(teacher_checkpoint=str(ck), beta=0.5)
+    sc['env_config'].update(device='cpu')
+    runner = Runner()
+    runner.load(scfg)
+    agent = runner.algo_factory.create(runner.algo_name, base_name='run', params=runner.params)
+    assert agent.distill is not None and agent.store_states
+    agent.train()
+    assert 'distill' in agent.aux_loss_dict
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Run: `venv/bin/python -m pytest tests/test_craftax_env.py -q -k end_to_end`
+Expected: FAIL (config file missing or `AttributeError: distill`)
+
+- [ ] **Step 3: Implement the hooks**
+
+`rl_games/common/experience.py` line ~340: `self.has_central_value = algo_info.get('store_states', algo_info['has_central_value'])` (the flag only gates the `states` tensor allocation).
+
+`rl_games/common/a2c_common.py`:
+
+```python
+        # (after self.has_central_value / self.state_space block, ~line 312)
+        self.distill_config = self.config.get('distillation', None)
+        self.distill = None                     # built by the agent after the model exists
+        self.store_states = self.has_central_value or self.distill_config is not None
+        if self.store_states and not hasattr(self, 'state_space'):
+            self.state_space = self.env_info.get('state_space', None) or self.observation_space
+```
+
+`init_tensors` algo_info: add `'store_states': self.store_states`.
+
+`play_steps` / `play_steps_rnn`: the two `if self.has_central_value: self.experience_buffer.update_data('states', ...)` become `if self.store_states:`.
+
+`get_action_values`: after `res_dict = self.inference_model()(input_dict)` (before the central-value block):
+
+```python
+            if self.distill is not None:
+                res_dict = self.distill.mix_actions(res_dict, obs['states'], self.epoch_num)
+```
+
+`prepare_dataset` (main dataset): after the `rollout_target_keys` loop:
+
+```python
+        if self.distill is not None:
+            dataset_dict['states'] = batch_dict['states']
+```
+
+Epoch logging (next to `info/last_lr`, line ~643):
+
+```python
+        if self.distill is not None:
+            self.distill.log(self.writer, self.epoch_num, frame)
+```
+
+Both agents, in `__init__` after the central value net is created (end of the `if self.has_central_value:` block):
+
+```python
+        if self.distill_config is not None:
+            from rl_games.common.distillation import TeacherDistillation
+            self.distill = TeacherDistillation.from_config(
+                self.distill_config, self.state_space.shape, self.actions_num, self.ppo_device)
+            if self.has_central_value and self.distill.warm_start_value:
+                self.distill.warm_start_central_value(self.central_value_net.model)
+```
+
+Both agents, in `calc_gradients`, right after `loss` is computed (both fused and regular branches end before the `aux_loss` block):
+
+```python
+            if self.distill is not None:
+                d_loss = self.distill.loss(res_dict, input_dict['states'], rnn_masks)
+                loss = self.distill.ppo_coef(self.epoch_num) * loss + self.distill.coef(self.epoch_num) * d_loss
+            aux_loss = self.model.get_aux_loss()
+            self.aux_loss_dict = {}
+            if self.distill is not None:
+                self.aux_loss_dict['distill'] = [d_loss.detach()]
+```
+
+(`a2c_discrete.py` has the same structure; `actions_num` is `self.actions_num` in both agents.)
+
+- [ ] **Step 4: Configs needed by the test** — create the three configs from Task 4 now (they are plain data), then run:
+
+Run: `venv/bin/python -m pytest tests/test_craftax_env.py tests/test_distillation.py -q`
+Expected: 10 passed
+
+Run the soccer + league regression to prove the plumbing change is inert elsewhere:
+`venv312/bin/python -m pytest tests/test_envpool_soccer.py tests/test_population_network.py -q` → 24 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add rl_games/common/a2c_common.py rl_games/common/experience.py rl_games/algos_torch/a2c_discrete.py rl_games/algos_torch/a2c_continuous.py rl_games/configs/craftax tests/test_craftax_env.py
+git commit -m "PPO: frozen-teacher distillation hooks (states in dataset, DAgger mixing, scheduled loss, CV warm start)"
+```
+
+---
+
+### Task 4: Configs and teacher training
+
+**Files:**
+- Create: `rl_games/configs/craftax/ppo_craftax_classic_symbolic.yaml`, `ppo_craftax_classic_pixels.yaml`, `ppo_craftax_classic_pixels_distill.yaml`
+- Create: `scripts/craftax_train.py` (attaches `CraftaxObserver`)
+
+Teacher config:
+
+```yaml
+params:
+  seed: 7
+  algo: {name: a2c_discrete}
+  model: {name: discrete_a2c}
+  network:
+    name: actor_critic
+    separate: False
+    space: {discrete: {}}
+    mlp: {units: [512, 512, 256], activation: elu, initializer: {name: default}}
+  config:
+    name: craftax_classic_symbolic
+    env_name: craftax
+    device: cuda
+    reward_shaper: {scale_value: 1.0}
+    normalize_advantage: True
+    normalize_input: True
+    normalize_value: True
+    value_bootstrap: False
+    gamma: 0.99
+    tau: 0.95
+    learning_rate: 3.0e-4
+    lr_schedule: adaptive
+    kl_threshold: 0.01
+    grad_norm: 1.0
+    truncate_grads: True
+    e_clip: 0.2
+    entropy_coef: 0.01
+    critic_coef: 1.0
+    clip_value: True
+    num_actors: 1024
+    horizon_length: 64
+    minibatch_size: 16384
+    mini_epochs: 4
+    max_epochs: 1500          # ~100M frames
+    save_best_after: 50
+    save_frequency: 250
+    score_to_win: 100000
+    games_to_track: 500
+    env_config: {game: Craftax-Classic-v1, obs: symbolic, seed: 7}
+```
+
+Student scratch config: same but `network` = cnn (32 k8 s4, 64 k4 s2, 64 k3 s1, `permute_input: True`, `normalize_input: False`) + mlp [512], `env_config.obs: pixels`, `minibatch_size: 8192`, `name: craftax_classic_pixels`.
+
+Distill config: student scratch + `env_config.obs: both`, `central_value_config` (network = teacher's MLP with `central_value: True`, `normalize_input: True`, minibatch 16384, mini_epochs 4, lr 3e-4), and
+
+```yaml
+    distillation:
+      teacher_config: rl_games/configs/craftax/ppo_craftax_classic_symbolic.yaml
+      teacher_checkpoint: runs/craftax_teacher/nn/craftax_classic_symbolic.pth
+      loss: kl
+      coef: [[0, 1.0], [300, 1.0], [600, 0.0]]
+      ppo_coef: [[0, 0.0], [300, 0.0], [301, 1.0]]
+      beta: [[0, 0.5], [150, 0.0]]
+      warm_start_value: True
+```
+
+`scripts/craftax_train.py`: like `soccer_train.py` — args `-f`, `-c`, `--max-epochs`, `--name`, `--train-dir`; `Runner(CraftaxObserver())`.
+
+Then: `venv/bin/python -u scripts/craftax_train.py -f rl_games/configs/craftax/ppo_craftax_classic_symbolic.yaml > craftax_teacher.log 2>&1` in the background; check fps and `craftax/score` after ~100 epochs.
+
+- [ ] Commit configs + script.
+
+### Task 5: Student runs and write-up
+
+- Student scratch and student distill, same `max_epochs`, launched after the teacher finishes; compare `craftax/score`, achievement rates and episode reward at equal frames; write `docs/DISTILLATION.md` with the mechanism, the configs, and the numbers.

--- a/docs/superpowers/specs/2026-09-05-teacher-distillation-design.md
+++ b/docs/superpowers/specs/2026-09-05-teacher-distillation-design.md
@@ -1,0 +1,99 @@
+# Frozen-teacher distillation inside PPO — design (2026-09-05)
+
+## Goal
+A distillation loss inside the existing PPO agent, with weight schedules,
+so that DAgger, DAgger -> PPO fine-tune and teacher-guided RL are config
+variants of one mechanism. The teacher is a frozen rl_games checkpoint that
+consumes privileged `states`; the student consumes `obs`. The student's
+central (asymmetric) value network is warm-started from the teacher.
+
+First application: vision. Craftax-Classic (Crafter in JAX) renders the same
+game state as a 1345-d symbolic vector (teacher) or a 63x63x3 image
+(student), at ~90k env-steps/s for 1024 envs on the GPU.
+
+## Components
+
+### 1. `CraftaxVecEnv` (`rl_games/envs/craftax_vecenv.py`, env name `craftax`)
+- kwargs: `game` (`Craftax-Classic-v1` | `Craftax-v1`), `obs`
+  (`symbolic` | `pixels` | `both`), `seed`, `device`.
+- Steps `jax.vmap(env.step)` under `jit` with craftax auto-reset (the obs
+  returned on done is the new episode's first obs, same-step autoreset);
+  torch tensors via dlpack (pattern of `PgxGoVecEnv`).
+- `obs: both` returns `{'obs': uint8 (N, 63, 63, 3), 'states': float32 (N, 1345)}`;
+  `get_env_info` exposes `observation_space` (Box uint8) and `state_space`
+  (Box float32) so rl_games' central-value plumbing picks `states` up.
+- `symbolic` / `pixels` return the single tensor. Discrete(17) actions.
+- Info on done: `achievements` (N, 22) float from craftax info, logged by a
+  `CraftaxObserver` as `craftax/<achievement>` rates and `craftax/score`
+  (Crafter geometric-mean score over achievements).
+
+### 2. `TeacherDistillation` (`rl_games/common/distillation.py`)
+Config block `distillation` in the algo config:
+
+```yaml
+distillation:
+  teacher_config: rl_games/configs/craftax/ppo_craftax_classic_symbolic.yaml
+  teacher_checkpoint: runs/.../nn/craftax_classic_symbolic.pth
+  loss: kl                 # discrete: KL(teacher || student); continuous: kl | mse
+  coef:  [[0, 1.0], [400, 1.0], [800, 0.0]]     # piecewise-linear in epochs
+  ppo_coef: [[0, 0.0], [400, 0.0], [401, 1.0]]  # 0 = pure DAgger phase
+  beta: [[0, 0.5], [200, 0.0]]                  # P(env action taken from teacher)
+  warm_start_value: True
+```
+- Teacher model built from `teacher_config`'s network with
+  `input_shape = state_space.shape`, weights from the checkpoint's `model`,
+  frozen, eval, on the agent device.
+- `coef(epoch)`, `ppo_coef(epoch)`, `beta(epoch)`: piecewise-linear
+  interpolation, constant outside the given range.
+- `loss(res_dict, states)`: discrete `sum p_t (log p_t - log p_s)` from
+  `res_dict['logits']`; continuous `kl` of diagonal Gaussians
+  (`mus`, `sigmas`) or `mse` on `mus`. Mean over rows (masked by
+  `rnn_masks` when present).
+- `mix_actions(res_dict, states, rng)`: with probability `beta` per row the
+  env action is the teacher's sample; `neglogpacs` is recomputed under the
+  student for the substituted rows (discrete: `-log_softmax(logits)[a]`;
+  continuous: Gaussian neglogp with `mus`/`sigmas`). Rows keep the student's
+  own action otherwise.
+- `warm_start_central_value(cv_model)`: copy every teacher tensor whose name
+  and shape match a tensor of the central-value model (trunk, value head,
+  `running_mean_std` on states, `value_mean_std`); print copied / skipped
+  counts. Requires the CV network to use the teacher's architecture.
+
+### 3. Agent hooks (`a2c_common.py`, `a2c_discrete.py`, `a2c_continuous.py`)
+- `self.distill = TeacherDistillation(...)` when the block is present.
+- `self.store_states = has_central_value or distill is not None`; the
+  experience buffer allocates `states` (algo_info `store_states`), rollouts
+  store `obs['states']`, `prepare_dataset` adds `states` to the main dataset
+  (minibatches then carry `input_dict['states']`).
+- `get_action_values`: after inference, `mix_actions` when `beta > 0`.
+- `calc_gradients` (both): `loss = ppo_coef * loss + coef * distill_loss`;
+  the distill term is logged through `aux_loss_dict['distill']`; the three
+  schedule values are written as `info/distill_coef`, `info/ppo_coef`,
+  `info/teacher_beta` each epoch.
+- Warm start runs once in `__init__` after the central value net exists.
+
+### 4. Configs (`rl_games/configs/craftax/`)
+- `ppo_craftax_classic_symbolic.yaml` — teacher: discrete PPO, MLP
+  [512, 512, 256] elu, 1024 envs, horizon 64, minibatch 16384, gamma 0.99.
+- `ppo_craftax_classic_pixels.yaml` — student from scratch: CNN (32/64/64
+  convs, `permute_input: True`, uint8 obs) + MLP 512, no teacher. Baseline.
+- `ppo_craftax_classic_pixels_distill.yaml` — same CNN student, `obs: both`,
+  `central_value_config` = teacher MLP on states (warm-started), the
+  `distillation` block above.
+
+### 5. Tests
+- `tests/test_distillation.py`: schedule interpolation; discrete KL equals a
+  manual computation and is 0 for identical logits; Gaussian KL and mse;
+  `mix_actions` substitutes ~beta of rows and recomputed neglogp matches
+  `Categorical(logits).log_prob`; warm start copies matching tensors and
+  skips mismatched ones.
+- `tests/test_craftax_env.py`: shapes/dtypes for the three obs modes,
+  `state_space` in env info, actions accepted as torch int64, autoreset
+  keeps shapes, achievements info on done. Integration: 2 epochs of the
+  distill config with 16 envs and a teacher checkpoint saved from a
+  freshly built (untrained) teacher.
+
+## Out of scope
+RNN students; dict `states`; multi-GPU teacher sync; DAgger data
+aggregation across epochs (PPO's on-policy buffer is the DAgger dataset by
+construction).

--- a/rl_games/algos_torch/a2c_continuous.py
+++ b/rl_games/algos_torch/a2c_continuous.py
@@ -35,6 +35,8 @@ class A2CAgent(a2c_common.ContinuousA2CBase):
             'normalize_input': self.normalize_input,
             'normalize_input_init_count': self.normalize_input_init_count,
         }
+        if self.store_states and hasattr(self, 'state_space'):
+            build_config['state_shape'] = self.state_space.shape
 
         self.model = self.network.build(build_config)
         self.model.to(self.ppo_device)
@@ -176,6 +178,8 @@ class A2CAgent(a2c_common.ContinuousA2CBase):
             'prev_actions': actions_batch,
             'obs': obs_batch,
         }
+        if self.state_aux_config is not None:
+            batch_dict['states'] = input_dict['states']
 
         # masks may exist without an RNN: next_step-autoreset garbage rows
         rnn_masks = input_dict.get('rnn_masks', None)

--- a/rl_games/algos_torch/a2c_continuous.py
+++ b/rl_games/algos_torch/a2c_continuous.py
@@ -76,6 +76,13 @@ class A2CAgent(a2c_common.ContinuousA2CBase):
             self.value_mean_std = self.central_value_net.model.value_mean_std if self.has_central_value else self.model.value_mean_std
 
         self.has_value_loss = self.use_experimental_cv or not self.has_central_value
+
+        if self.distill_config is not None:
+            from rl_games.common.distillation import TeacherDistillation
+            self.distill = TeacherDistillation.from_config(
+                self.distill_config, self.state_space.shape, self.actions_num, self.ppo_device)
+            if self.has_central_value and self.distill.warm_start_value:
+                self.distill.warm_start_central_value(self.central_value_net.model)
         self.algo_observer.after_init(self)
 
     def update_epoch(self):
@@ -202,8 +209,13 @@ class A2CAgent(a2c_common.ContinuousA2CBase):
                 rnn_masks
             )
 
+            if self.distill is not None:
+                d_loss = self.distill.loss(res_dict, input_dict['states'], rnn_masks)
+                loss = self.distill.ppo_coef(self.epoch_num) * loss + self.distill.coef(self.epoch_num) * d_loss
             aux_loss = self.model.get_aux_loss()
             self.aux_loss_dict = {}
+            if self.distill is not None:
+                self.aux_loss_dict['distill'] = [d_loss.detach()]
             if aux_loss is not None:
                 for k, v in aux_loss.items():
                     loss += v

--- a/rl_games/algos_torch/a2c_discrete.py
+++ b/rl_games/algos_torch/a2c_discrete.py
@@ -38,6 +38,8 @@ class DiscreteA2CAgent(a2c_common.DiscreteA2CBase):
             'normalize_input': self.normalize_input,
             'normalize_input_init_count': self.normalize_input_init_count,
         }
+        if self.store_states and hasattr(self, 'state_space'):
+            build_config['state_shape'] = self.state_space.shape
 
         self.model = self.network.build(config)
         self.model.to(self.ppo_device)
@@ -152,6 +154,8 @@ class DiscreteA2CAgent(a2c_common.DiscreteA2CBase):
             'prev_actions': actions_batch,
             'obs': obs_batch,
         }
+        if self.state_aux_config is not None:
+            batch_dict['states'] = input_dict['states']
         if self.use_action_masks:
             batch_dict['action_masks'] = input_dict['action_masks']
 

--- a/rl_games/algos_torch/a2c_discrete.py
+++ b/rl_games/algos_torch/a2c_discrete.py
@@ -78,6 +78,13 @@ class DiscreteA2CAgent(a2c_common.DiscreteA2CBase):
         if self.normalize_value:
             self.value_mean_std = self.central_value_net.model.value_mean_std if self.has_central_value else self.model.value_mean_std
         self.has_value_loss = self.use_experimental_cv or not self.has_central_value
+
+        if self.distill_config is not None:
+            from rl_games.common.distillation import TeacherDistillation
+            self.distill = TeacherDistillation.from_config(
+                self.distill_config, self.state_space.shape, self.actions_num, self.ppo_device)
+            if self.has_central_value and self.distill.warm_start_value:
+                self.distill.warm_start_central_value(self.central_value_net.model)
         self.algo_observer.after_init(self)
 
     def update_epoch(self):
@@ -178,8 +185,13 @@ class DiscreteA2CAgent(a2c_common.DiscreteA2CBase):
             losses, sum_mask = torch_ext.apply_masks([a_loss.unsqueeze(1), c_loss, entropy.unsqueeze(1)], rnn_masks)
             a_loss, c_loss, entropy = losses[0], losses[1], losses[2]
             loss = a_loss + 0.5 * c_loss * self.critic_coef - entropy * self.entropy_coef
+            if self.distill is not None:
+                d_loss = self.distill.loss(res_dict, input_dict['states'], rnn_masks)
+                loss = self.distill.ppo_coef(self.epoch_num) * loss + self.distill.coef(self.epoch_num) * d_loss
             aux_loss = self.model.get_aux_loss()
             self.aux_loss_dict = {}
+            if self.distill is not None:
+                self.aux_loss_dict['distill'] = [d_loss.detach()]
             if aux_loss is not None:
                 for k, v in aux_loss.items():
                     loss += v

--- a/rl_games/algos_torch/model_builder.py
+++ b/rl_games/algos_torch/model_builder.py
@@ -6,6 +6,11 @@ from rl_games.algos_torch import models
 NETWORK_REGISTRY = {}
 MODEL_REGISTRY = {}
 
+def _build_state_aux():
+    from rl_games.algos_torch.state_aux_network import StateAuxBuilder
+    return StateAuxBuilder()
+
+
 def register_network(name, target_class):
     NETWORK_REGISTRY[name] = lambda **kwargs: target_class()
 
@@ -18,6 +23,7 @@ class NetworkBuilder:
         self.network_factory = object_factory.ObjectFactory()
         self.network_factory.set_builders(NETWORK_REGISTRY)
         self.network_factory.register_builder('actor_critic', lambda **kwargs: network_builder.A2CBuilder())
+        self.network_factory.register_builder('actor_critic_state_aux', lambda **kwargs: _build_state_aux())
         self.network_factory.register_builder('resnet_actor_critic',
                                               lambda **kwargs: network_builder.A2CResnetBuilder())
         self.network_factory.register_builder('rnd_curiosity', lambda **kwargs: network_builder.RNDCuriosityBuilder())

--- a/rl_games/algos_torch/models.py
+++ b/rl_games/algos_torch/models.py
@@ -62,7 +62,9 @@ class BaseModelNetwork(nn.Module):
             return self.value_mean_std(value, denorm=True) if self.normalize_value else value
 
     def get_aux_loss(self):
-        return None
+        # networks may expose auxiliary losses (e.g. actor_critic_state_aux)
+        fn = getattr(self.a2c_network, 'get_aux_loss', None)
+        return fn() if fn is not None else None
 
 
 class ModelA2C(BaseModel):

--- a/rl_games/algos_torch/state_aux_network.py
+++ b/rl_games/algos_torch/state_aux_network.py
@@ -1,0 +1,75 @@
+"""actor_critic_state_aux: standard actor-critic plus an auxiliary head that
+regresses the privileged `states` vector from the actor trunk's last hidden
+layer. No teacher: the privileged information is used only as a prediction
+target, so it can be compared with frozen-teacher distillation
+(rl_games/common/distillation.py) on the same pixel student.
+
+Config, under `network`:
+
+    name: actor_critic_state_aux
+    state_aux:
+      coef: 1.0            # weight of the MSE (on running-normalised targets)
+      units: [256]         # hidden layers of the head
+      indices: null        # optional list of state dims to predict (default all)
+    ... (cnn / mlp / space as for actor_critic)
+
+The agent must store `states` (algo config `state_aux: {}` turns that on; the
+env returns {'obs': ..., 'states': ...}) and passes `state_shape` in the
+build config. The loss is picked up through the model's get_aux_loss().
+"""
+
+import torch
+import torch.nn as nn
+
+from rl_games.algos_torch import network_builder
+from rl_games.algos_torch.running_mean_std import RunningMeanStd
+
+
+class StateAuxBuilder(network_builder.A2CBuilder):
+    def build(self, name, **kwargs):
+        return StateAuxBuilder.Network(self.params, **kwargs)
+
+    class Network(network_builder.A2CBuilder.Network):
+        def __init__(self, params, **kwargs):
+            state_shape = kwargs.pop('state_shape', None)
+            super().__init__(params, **kwargs)
+            if self.separate:
+                raise NotImplementedError('actor_critic_state_aux needs a shared trunk (separate: False)')
+            if state_shape is None:
+                raise ValueError("actor_critic_state_aux needs 'state_shape' in the build config "
+                                 "(set algo config `state_aux: {}` and an env that returns states)")
+            cfg = params.get('state_aux', {})
+            self.aux_coef = float(cfg.get('coef', 1.0))
+            indices = cfg.get('indices', None)
+            self.register_buffer('aux_indices',
+                                 torch.as_tensor(indices, dtype=torch.long) if indices is not None else torch.empty(0, dtype=torch.long))
+            out_dim = len(indices) if indices is not None else int(state_shape[0])
+            units = list(cfg.get('units', [256]))
+            latent = self.units[-1] if len(self.units) else self._calc_input_size(self.actor_cnn, kwargs.get('input_shape'))
+            layers, size = [], latent
+            for u in units:
+                layers += [nn.Linear(size, u), nn.ELU()]
+                size = u
+            layers.append(nn.Linear(size, out_dim))
+            self.aux_head = nn.Sequential(*layers)
+            self.aux_target_norm = RunningMeanStd((out_dim,))
+            self._latent = None
+            self._aux_loss = None
+            self.actor_mlp.register_forward_hook(lambda m, i, o: setattr(self, '_latent', o))
+
+        def forward(self, obs_dict):
+            out = super().forward(obs_dict)
+            states = obs_dict.get('states', None)
+            if states is not None and obs_dict.get('is_train', True) and self._latent is not None:
+                target = states.float()
+                if self.aux_indices.numel():
+                    target = target[:, self.aux_indices]
+                with torch.no_grad():
+                    target = self.aux_target_norm(target)          # updates stats in train mode
+                pred = self.aux_head(self._latent)
+                self._aux_loss = self.aux_coef * torch.mean((pred - target) ** 2)
+            return out
+
+        def get_aux_loss(self):
+            loss, self._aux_loss = self._aux_loss, None
+            return {'state_aux': loss} if loss is not None else None

--- a/rl_games/common/a2c_common.py
+++ b/rl_games/common/a2c_common.py
@@ -1757,6 +1757,8 @@ class ContinuousA2CBase(A2CBase):
         dataset_dict['rnn_masks'] = rnn_masks
         dataset_dict['mu'] = mus
         dataset_dict['sigma'] = sigmas
+        if self.distill is not None:
+            dataset_dict['states'] = batch_dict['states']
 
         self.dataset.update_values_dict(dataset_dict)
 

--- a/rl_games/common/a2c_common.py
+++ b/rl_games/common/a2c_common.py
@@ -307,6 +307,14 @@ class A2CBase(BaseAlgorithm):
             else:
                 self.state_shape = self.state_space.shape
 
+        # Frozen-teacher distillation (rl_games/common/distillation.py): the
+        # teacher consumes privileged `states`, so they are stored and passed
+        # into minibatches even without a central value net.
+        self.distill_config = self.config.get('distillation', None)
+        self.distill = None                     # built by the agent once the model exists
+        self.store_states = self.has_central_value or self.distill_config is not None
+        if self.store_states and not hasattr(self, 'state_space'):
+            self.state_space = self.env_info.get('state_space', None) or self.observation_space
         self.self_play_config = self.config.get('self_play_config', None)
         self.has_self_play_config = self.self_play_config is not None
 
@@ -628,6 +636,8 @@ class A2CBase(BaseAlgorithm):
         for k, v in self.aux_loss_dict.items():
             self.writer.add_scalar('losses/' + k, torch_ext.mean_list(v).item(), frame)
         self.writer.add_scalar('info/last_lr', last_lr * lr_mul, frame)
+        if self.distill is not None:
+            self.distill.log(self.writer, self.epoch_num, frame)
         self.writer.add_scalar('info/lr_mul', lr_mul, frame)
         self.writer.add_scalar('info/e_clip', self.e_clip * lr_mul, frame)
         self.writer.add_scalar('info/kl', torch_ext.mean_list(kls).item(), frame)
@@ -688,6 +698,8 @@ class A2CBase(BaseAlgorithm):
 
         with torch.no_grad():
             res_dict = self.inference_model()(input_dict)
+            if self.distill is not None:
+                res_dict = self.distill.mix_actions(res_dict, obs['states'], self.epoch_num)
             if self.has_central_value:
                 states = obs['states']
                 input_dict = {
@@ -739,6 +751,7 @@ class A2CBase(BaseAlgorithm):
             'num_actors': self.num_actors,
             'horizon_length': self.horizon_length,
             'has_central_value': self.has_central_value,
+            'store_states': self.store_states,
             'use_action_masks': self.use_action_masks
         }
         self.experience_buffer = ExperienceBuffer(self.env_info, algo_info, self.ppo_device)
@@ -1114,7 +1127,7 @@ class A2CBase(BaseAlgorithm):
 
             for k in update_list:
                 self.experience_buffer.update_data(k, n, res_dict[k])
-            if self.has_central_value:
+            if self.store_states:
                 self.experience_buffer.update_data('states', n, self.obs['states'])
 
             step_time_start = time.perf_counter()
@@ -1222,7 +1235,7 @@ class A2CBase(BaseAlgorithm):
 
             for k in update_list:
                 self.experience_buffer.update_data(k, n, res_dict[k])
-            if self.has_central_value:
+            if self.store_states:
                 self.experience_buffer.update_data('states', n, self.obs['states'])
 
             step_time_start = time.perf_counter()
@@ -1453,6 +1466,9 @@ class DiscreteA2CBase(A2CBase):
 
         if self.use_action_masks:
             dataset_dict['action_masks'] = batch_dict['action_masks']
+
+        if self.distill is not None:
+            dataset_dict['states'] = batch_dict['states']
 
         self.dataset.update_values_dict(dataset_dict)
         if self.has_central_value:

--- a/rl_games/common/a2c_common.py
+++ b/rl_games/common/a2c_common.py
@@ -312,7 +312,10 @@ class A2CBase(BaseAlgorithm):
         # into minibatches even without a central value net.
         self.distill_config = self.config.get('distillation', None)
         self.distill = None                     # built by the agent once the model exists
-        self.store_states = self.has_central_value or self.distill_config is not None
+        # state_aux: {} -> the network regresses `states` as an auxiliary loss (actor_critic_state_aux)
+        self.state_aux_config = self.config.get('state_aux', None)
+        self.store_states = (self.has_central_value or self.distill_config is not None
+                             or self.state_aux_config is not None)
         if self.store_states and not hasattr(self, 'state_space'):
             self.state_space = self.env_info.get('state_space', None) or self.observation_space
         self.self_play_config = self.config.get('self_play_config', None)
@@ -1467,7 +1470,7 @@ class DiscreteA2CBase(A2CBase):
         if self.use_action_masks:
             dataset_dict['action_masks'] = batch_dict['action_masks']
 
-        if self.distill is not None:
+        if self.distill is not None or self.state_aux_config is not None:
             dataset_dict['states'] = batch_dict['states']
 
         self.dataset.update_values_dict(dataset_dict)
@@ -1757,7 +1760,7 @@ class ContinuousA2CBase(A2CBase):
         dataset_dict['rnn_masks'] = rnn_masks
         dataset_dict['mu'] = mus
         dataset_dict['sigma'] = sigmas
-        if self.distill is not None:
+        if self.distill is not None or self.state_aux_config is not None:
             dataset_dict['states'] = batch_dict['states']
 
         self.dataset.update_values_dict(dataset_dict)

--- a/rl_games/common/distillation.py
+++ b/rl_games/common/distillation.py
@@ -19,6 +19,7 @@ Config (algo `config.distillation`):
       ppo_coef: [[0, 0.0], [400, 0.0], [401, 1.0]]
       beta: [[0, 0.5], [200, 0.0]]
       warm_start_value: True   # copy matching teacher tensors into the central value net
+      teacher_mu_clip: 1.0     # continuous only: clamp teacher means to the action range
 
 Because PPO's on-policy buffer is rebuilt from the student's own rollouts
 every epoch, the distillation term IS DAgger: supervised on the states the
@@ -68,6 +69,9 @@ class TeacherDistillation:
         self._ppo_coef = config.get('ppo_coef', 1.0)
         self._beta = config.get('beta', 0.0)
         self.warm_start_value = bool(config.get('warm_start_value', True))
+        # continuous: clamp the teacher's means to +-clip before the loss (the env
+        # clips actions anyway; unbounded teacher means are unreachable targets)
+        self.teacher_mu_clip = config.get('teacher_mu_clip', None)
         self.last_loss = None
 
     # ----------------------------------------------------------- schedules
@@ -118,6 +122,9 @@ class TeacherDistillation:
         else:
             mu_s, sig_s = res_dict['mus'].float(), res_dict['sigmas'].float()
             mu_t, sig_t = t['mus'].float(), t['sigmas'].float()
+            if self.teacher_mu_clip is not None:
+                c = float(self.teacher_mu_clip)
+                mu_t = mu_t.clamp(-c, c)
             if self.loss_type == 'mse':
                 per_row = ((mu_t - mu_s) ** 2).sum(dim=-1)
             else:

--- a/rl_games/common/distillation.py
+++ b/rl_games/common/distillation.py
@@ -1,0 +1,189 @@
+"""Frozen-teacher distillation inside PPO (DAgger as a loss term).
+
+The teacher is a frozen rl_games policy that consumes privileged `states`;
+the student consumes `obs`. Three piecewise-linear schedules over epochs:
+
+  coef      weight of the distillation loss on student-visited states
+  ppo_coef  weight of the PPO loss (0 -> pure DAgger phase)
+  beta      P(env action taken from the teacher) — classic DAgger mixing;
+            the student's neglogp is recomputed for substituted rows so PPO
+            importance ratios stay valid.
+
+Config (algo `config.distillation`):
+
+    distillation:
+      teacher_config: <yaml with the teacher's params>
+      teacher_checkpoint: <rl_games .pth>
+      loss: kl                 # discrete: KL(teacher||student); continuous: kl | mse
+      coef: [[0, 1.0], [400, 1.0], [800, 0.0]]
+      ppo_coef: [[0, 0.0], [400, 0.0], [401, 1.0]]
+      beta: [[0, 0.5], [200, 0.0]]
+      warm_start_value: True   # copy matching teacher tensors into the central value net
+
+Because PPO's on-policy buffer is rebuilt from the student's own rollouts
+every epoch, the distillation term IS DAgger: supervised on the states the
+student visits. With ppo_coef 0 it is pure DAgger; ramping ppo_coef up and
+coef down gives DAgger -> PPO fine-tune; both on gives teacher-guided RL.
+"""
+
+import numpy as np
+import torch
+import yaml
+
+
+def piecewise_linear(spec, epoch):
+    """[[epoch, value], ...] -> value at `epoch` (linear between knots,
+    constant outside). A scalar spec is a constant; None is 0."""
+    if spec is None:
+        return 0.0
+    if isinstance(spec, (int, float)):
+        return float(spec)
+    knots = sorted((float(e), float(v)) for e, v in spec)
+    if epoch <= knots[0][0]:
+        return knots[0][1]
+    for (e0, v0), (e1, v1) in zip(knots[:-1], knots[1:]):
+        if e0 <= epoch <= e1:
+            if e1 == e0:
+                return v1
+            return v0 + (v1 - v0) * (epoch - e0) / (e1 - e0)
+    return knots[-1][1]
+
+
+def _strip_prefix(sd, prefix='_orig_mod.'):
+    return {k[len(prefix):] if k.startswith(prefix) else k: v for k, v in sd.items()}
+
+
+class TeacherDistillation:
+    def __init__(self, config, teacher_model, is_discrete, device):
+        self.config = config
+        self.teacher = teacher_model.to(device).eval()
+        for p in self.teacher.parameters():
+            p.requires_grad_(False)
+        self.is_discrete = is_discrete
+        self.device = device
+        self.loss_type = config.get('loss', 'kl')
+        if self.loss_type not in ('kl', 'mse'):
+            raise ValueError("distillation loss must be 'kl' or 'mse'")
+        self._coef = config.get('coef', 1.0)
+        self._ppo_coef = config.get('ppo_coef', 1.0)
+        self._beta = config.get('beta', 0.0)
+        self.warm_start_value = bool(config.get('warm_start_value', True))
+        self.last_loss = None
+
+    # ----------------------------------------------------------- schedules
+
+    def coef(self, epoch):
+        return piecewise_linear(self._coef, epoch)
+
+    def ppo_coef(self, epoch):
+        return piecewise_linear(self._ppo_coef, epoch)
+
+    def beta(self, epoch):
+        return piecewise_linear(self._beta, epoch)
+
+    # ------------------------------------------------------------- teacher
+
+    @torch.no_grad()
+    def teacher_forward(self, states):
+        return self.teacher({'obs': states, 'is_train': False})
+
+    @classmethod
+    def from_config(cls, config, state_shape, actions_num, device):
+        """Build the frozen teacher from its own yaml + checkpoint."""
+        from rl_games.algos_torch.model_builder import ModelBuilder
+        params = yaml.safe_load(open(config['teacher_config']))['params']
+        net = ModelBuilder().load(params)
+        tcfg = params['config']
+        model = net.build({'actions_num': actions_num, 'input_shape': tuple(state_shape), 'num_seqs': 1,
+                           'value_size': tcfg.get('value_size', 1),
+                           'normalize_value': tcfg.get('normalize_value', False),
+                           'normalize_input': tcfg.get('normalize_input', False)})
+        ckpt = torch.load(config['teacher_checkpoint'], map_location=device, weights_only=False)
+        model.load_state_dict(_strip_prefix(ckpt['model']))
+        is_discrete = params['algo']['name'] == 'a2c_discrete'
+        print(f"[Distillation] teacher {config['teacher_checkpoint']} (epoch {ckpt.get('epoch', '?')}), "
+              f"{'discrete' if is_discrete else 'continuous'}, coef {config.get('coef')}, "
+              f"ppo_coef {config.get('ppo_coef')}, beta {config.get('beta')}")
+        return cls(config, model, is_discrete, device)
+
+    # ---------------------------------------------------------------- loss
+
+    def loss(self, res_dict, states, rnn_masks=None):
+        """Mean distillation loss over rows (masked when rnn_masks given)."""
+        t = self.teacher_forward(states)
+        if self.is_discrete:
+            logp_t = torch.log_softmax(t['logits'].float(), dim=-1)
+            logp_s = torch.log_softmax(res_dict['logits'].float(), dim=-1)
+            per_row = (logp_t.exp() * (logp_t - logp_s)).sum(dim=-1)
+        else:
+            mu_s, sig_s = res_dict['mus'].float(), res_dict['sigmas'].float()
+            mu_t, sig_t = t['mus'].float(), t['sigmas'].float()
+            if self.loss_type == 'mse':
+                per_row = ((mu_t - mu_s) ** 2).sum(dim=-1)
+            else:
+                per_row = (torch.log(sig_s / sig_t)
+                           + (sig_t ** 2 + (mu_t - mu_s) ** 2) / (2 * sig_s ** 2) - 0.5).sum(dim=-1)
+        if rnn_masks is not None:
+            m = rnn_masks.reshape(-1).float()
+            out = (per_row * m).sum() / m.sum().clamp(min=1.0)
+        else:
+            out = per_row.mean()
+        self.last_loss = out.detach()
+        return out
+
+    # ------------------------------------------------------------- mixing
+
+    def mix_actions(self, res_dict, states, epoch):
+        """DAgger beta-mixing on the rollout batch: substitute the teacher's
+        sampled action for a Bernoulli(beta) subset of rows and recompute the
+        student's neglogp for those rows."""
+        beta = self.beta(epoch)
+        if beta <= 0.0:
+            return res_dict
+        n = states.shape[0]
+        sel = torch.rand(n, device=states.device) < beta
+        if not bool(sel.any()):
+            return res_dict
+        t = self.teacher_forward(states[sel])
+        actions = res_dict['actions'].clone()
+        if self.is_discrete:
+            ta = torch.distributions.Categorical(logits=t['logits'].float()).sample()
+            actions[sel] = ta.to(actions.dtype)
+            neglogp = -torch.log_softmax(res_dict['logits'].float(), dim=-1).gather(
+                1, actions.view(-1, 1).long()).squeeze(1)
+        else:
+            ta = torch.distributions.Normal(t['mus'].float(), t['sigmas'].float()).sample()
+            actions[sel] = ta.to(actions.dtype)
+            mus, sig = res_dict['mus'].float(), res_dict['sigmas'].float()
+            neglogp = 0.5 * (((actions.float() - mus) / sig) ** 2).sum(-1) \
+                + 0.5 * np.log(2.0 * np.pi) * actions.shape[-1] + torch.log(sig).sum(-1)
+        res_dict['actions'] = actions
+        res_dict['neglogpacs'] = neglogp.to(res_dict['neglogpacs'].dtype)
+        return res_dict
+
+    # ---------------------------------------------------------- warm start
+
+    def warm_start_central_value(self, cv_model):
+        """Copy every teacher tensor whose name and shape match into the
+        central-value model (trunk, value head, input/value normalisers)."""
+        tsd = _strip_prefix(self.teacher.state_dict())
+        csd = cv_model.state_dict()
+        new, copied, skipped = {}, 0, 0
+        for k, v in csd.items():
+            if k in tsd and tuple(tsd[k].shape) == tuple(v.shape):
+                new[k] = tsd[k].to(v.device, v.dtype)
+                copied += 1
+            else:
+                skipped += 1
+        cv_model.load_state_dict(new, strict=False)
+        print(f'[Distillation] warm-started central value: {copied} tensors copied, {skipped} skipped')
+        return copied, skipped
+
+    # ------------------------------------------------------------- logging
+
+    def log(self, writer, epoch, frame):
+        if writer is None:
+            return
+        writer.add_scalar('info/distill_coef', self.coef(epoch), frame)
+        writer.add_scalar('info/ppo_coef', self.ppo_coef(epoch), frame)
+        writer.add_scalar('info/teacher_beta', self.beta(epoch), frame)

--- a/rl_games/common/env_configurations.py
+++ b/rl_games/common/env_configurations.py
@@ -326,6 +326,9 @@ configurations = {
     'craftax' : {
         'vecenv_type': 'CRAFTAX'
     },
+    'playground' : {
+        'vecenv_type': 'PLAYGROUND'
+    },
 }
 
 def get_env_info(env):

--- a/rl_games/common/env_configurations.py
+++ b/rl_games/common/env_configurations.py
@@ -323,6 +323,9 @@ configurations = {
     'pufferlib' : {
         'vecenv_type': 'PUFFERLIB'
     },
+    'craftax' : {
+        'vecenv_type': 'CRAFTAX'
+    },
 }
 
 def get_env_info(env):

--- a/rl_games/common/experience.py
+++ b/rl_games/common/experience.py
@@ -337,7 +337,8 @@ class ExperienceBuffer:
 
         self.num_actors = algo_info['num_actors']
         self.horizon_length = algo_info['horizon_length']
-        self.has_central_value = algo_info['has_central_value']
+        # 'states' are stored for a central value net OR for teacher distillation
+        self.has_central_value = algo_info.get('store_states', algo_info['has_central_value'])
         self.use_action_masks = algo_info.get('use_action_masks', False)
         batch_size = self.num_actors * self.num_agents
         self.is_discrete = False

--- a/rl_games/common/vecenv.py
+++ b/rl_games/common/vecenv.py
@@ -418,3 +418,8 @@ def _create_craftax(config_name, num_actors, **kwargs):
     from rl_games.envs.craftax_vecenv import CraftaxVecEnv
     return CraftaxVecEnv(config_name, num_actors, **kwargs)
 register('CRAFTAX', _create_craftax)
+
+def _create_playground(config_name, num_actors, **kwargs):
+    from rl_games.envs.playground_vecenv import PlaygroundVecEnv
+    return PlaygroundVecEnv(config_name, num_actors, **kwargs)
+register('PLAYGROUND', _create_playground)

--- a/rl_games/common/vecenv.py
+++ b/rl_games/common/vecenv.py
@@ -413,3 +413,8 @@ def _create_mjlab(config_name, num_actors, **kwargs):
     from rl_games.envs.mjlab_vecenv import MjlabVecEnv
     return MjlabVecEnv(config_name, num_actors, **kwargs)
 register('MJLAB', _create_mjlab)
+
+def _create_craftax(config_name, num_actors, **kwargs):
+    from rl_games.envs.craftax_vecenv import CraftaxVecEnv
+    return CraftaxVecEnv(config_name, num_actors, **kwargs)
+register('CRAFTAX', _create_craftax)

--- a/rl_games/configs/craftax/ppo_craftax_classic_pixels.yaml
+++ b/rl_games/configs/craftax/ppo_craftax_classic_pixels.yaml
@@ -1,0 +1,85 @@
+# Craftax-Classic PIXELS (63x63x3) — pixel STUDENT trained from scratch, no
+# teacher. Baseline for ppo_craftax_classic_pixels_distill.yaml.
+#
+#   python scripts/craftax_train.py -f rl_games/configs/craftax/ppo_craftax_classic_pixels.yaml
+params:
+  seed: 7
+
+  algo:
+    name: a2c_discrete
+
+  model:
+    name: discrete_a2c
+
+  network:
+    name: actor_critic
+    separate: False
+    space:
+      discrete:
+    cnn:
+      permute_input: True        # obs arrives (B, H, W, C) uint8
+      type: conv2d
+      activation: elu
+      initializer:
+        name: default
+      regularizer:
+        name: None
+      convs:
+        - filters: 32
+          kernel_size: 8
+          strides: 4
+          padding: 0
+        - filters: 64
+          kernel_size: 4
+          strides: 2
+          padding: 0
+        - filters: 64
+          kernel_size: 3
+          strides: 1
+          padding: 0
+    mlp:
+      units: [512]
+      activation: elu
+      initializer:
+        name: default
+  config:
+    name: craftax_classic_pixels
+    env_name: craftax
+    device: cuda
+
+    reward_shaper:
+      scale_value: 1.0
+
+    normalize_advantage: True
+    normalize_input: False     # uint8 pixels are scaled by 1/255 in _preproc_obs
+    normalize_value: True
+    value_bootstrap: False
+
+    gamma: 0.99
+    tau: 0.95
+    learning_rate: 3.0e-4
+    lr_schedule: adaptive
+    kl_threshold: 0.01
+
+    grad_norm: 1.0
+    truncate_grads: True
+    e_clip: 0.2
+    entropy_coef: 0.01
+    critic_coef: 1.0
+    clip_value: True
+
+    num_actors: 1024
+    horizon_length: 64
+    minibatch_size: 8192
+    mini_epochs: 4
+
+    max_epochs: 1500
+    save_best_after: 50
+    save_frequency: 250
+    score_to_win: 100000
+    games_to_track: 500
+
+    env_config:
+      game: Craftax-Classic-v1
+      obs: pixels
+      seed: 7

--- a/rl_games/configs/craftax/ppo_craftax_classic_pixels_distill.yaml
+++ b/rl_games/configs/craftax/ppo_craftax_classic_pixels_distill.yaml
@@ -1,0 +1,116 @@
+# Craftax-Classic PIXELS student DISTILLED from the symbolic teacher
+# (ppo_craftax_classic_symbolic.yaml) — frozen-teacher distillation inside PPO
+# (rl_games/common/distillation.py). Env returns {'obs': pixels, 'states':
+# symbolic}; the teacher and the central value net consume states.
+#
+# Schedule (epochs): 0-300 pure DAgger (ppo_coef 0, KL to teacher, beta
+# 0.5 -> 0 by 150), 300-600 PPO fine-tune with the KL fading to 0, then PPO.
+# The central value net is the teacher's MLP, warm-started from the teacher.
+#
+#   python scripts/craftax_train.py -f rl_games/configs/craftax/ppo_craftax_classic_pixels_distill.yaml
+params:
+  seed: 7
+
+  algo:
+    name: a2c_discrete
+
+  model:
+    name: discrete_a2c
+
+  network:
+    name: actor_critic
+    separate: False
+    space:
+      discrete:
+    cnn:
+      permute_input: True        # obs arrives (B, H, W, C) uint8
+      type: conv2d
+      activation: elu
+      initializer:
+        name: default
+      regularizer:
+        name: None
+      convs:
+        - filters: 32
+          kernel_size: 8
+          strides: 4
+          padding: 0
+        - filters: 64
+          kernel_size: 4
+          strides: 2
+          padding: 0
+        - filters: 64
+          kernel_size: 3
+          strides: 1
+          padding: 0
+    mlp:
+      units: [512]
+      activation: elu
+      initializer:
+        name: default
+  config:
+    name: craftax_classic_pixels_distill
+    env_name: craftax
+    device: cuda
+
+    reward_shaper:
+      scale_value: 1.0
+
+    normalize_advantage: True
+    normalize_input: False     # uint8 pixels are scaled by 1/255 in _preproc_obs
+    normalize_value: True
+    value_bootstrap: False
+
+    gamma: 0.99
+    tau: 0.95
+    learning_rate: 3.0e-4
+    lr_schedule: adaptive
+    kl_threshold: 0.01
+
+    grad_norm: 1.0
+    truncate_grads: True
+    e_clip: 0.2
+    entropy_coef: 0.01
+    critic_coef: 1.0
+    clip_value: True
+
+    num_actors: 1024
+    horizon_length: 64
+    minibatch_size: 8192
+    mini_epochs: 4
+
+    max_epochs: 1500
+    save_best_after: 50
+    save_frequency: 250
+    score_to_win: 100000
+    games_to_track: 500
+
+    central_value_config:
+      minibatch_size: 16384
+      mini_epochs: 4
+      learning_rate: 3.0e-4
+      clip_value: True
+      normalize_input: True
+      truncate_grads: True
+      network:
+        name: actor_critic
+        central_value: True
+        mlp:
+          units: [512, 512, 256]
+          activation: elu
+          initializer:
+            name: default
+
+    distillation:
+      teacher_config: rl_games/configs/craftax/ppo_craftax_classic_symbolic.yaml
+      teacher_checkpoint: runs/craftax_teacher/nn/craftax_classic_symbolic.pth
+      loss: kl
+      coef: [[0, 1.0], [300, 1.0], [600, 0.0]]
+      ppo_coef: [[0, 0.0], [300, 0.0], [301, 1.0]]
+      beta: [[0, 0.5], [150, 0.0]]
+      warm_start_value: True
+
+    env_config:
+      game: Craftax-Classic-v1
+      obs: both
+      seed: 7

--- a/rl_games/configs/craftax/ppo_craftax_classic_pixels_distill.yaml
+++ b/rl_games/configs/craftax/ppo_craftax_classic_pixels_distill.yaml
@@ -103,7 +103,7 @@ params:
 
     distillation:
       teacher_config: rl_games/configs/craftax/ppo_craftax_classic_symbolic.yaml
-      teacher_checkpoint: runs/craftax_teacher/nn/craftax_classic_symbolic.pth
+      teacher_checkpoint: runs/craftax_classic_symbolic_05-11-32-19/nn/craftax_classic_symbolic.pth
       loss: kl
       coef: [[0, 1.0], [300, 1.0], [600, 0.0]]
       ppo_coef: [[0, 0.0], [300, 0.0], [301, 1.0]]

--- a/rl_games/configs/craftax/ppo_craftax_classic_symbolic.yaml
+++ b/rl_games/configs/craftax/ppo_craftax_classic_symbolic.yaml
@@ -1,0 +1,66 @@
+# Craftax-Classic (Crafter in JAX), SYMBOLIC 1345-d observation — the TEACHER
+# for rl_games/common/distillation.py. Discrete PPO, MLP. 1024 envs on GPU,
+# ~90k env-steps/s; 1500 epochs = ~100M frames.
+#
+#   python scripts/craftax_train.py -f rl_games/configs/craftax/ppo_craftax_classic_symbolic.yaml
+params:
+  seed: 7
+
+  algo:
+    name: a2c_discrete
+
+  model:
+    name: discrete_a2c
+
+  network:
+    name: actor_critic
+    separate: False
+    space:
+      discrete:
+    mlp:
+      units: [512, 512, 256]
+      activation: elu
+      initializer:
+        name: default
+
+  config:
+    name: craftax_classic_symbolic
+    env_name: craftax
+    device: cuda
+
+    reward_shaper:
+      scale_value: 1.0
+
+    normalize_advantage: True
+    normalize_input: True
+    normalize_value: True
+    value_bootstrap: False
+
+    gamma: 0.99
+    tau: 0.95
+    learning_rate: 3.0e-4
+    lr_schedule: adaptive
+    kl_threshold: 0.01
+
+    grad_norm: 1.0
+    truncate_grads: True
+    e_clip: 0.2
+    entropy_coef: 0.01
+    critic_coef: 1.0
+    clip_value: True
+
+    num_actors: 1024
+    horizon_length: 64
+    minibatch_size: 16384
+    mini_epochs: 4
+
+    max_epochs: 1500
+    save_best_after: 50
+    save_frequency: 250
+    score_to_win: 100000
+    games_to_track: 500
+
+    env_config:
+      game: Craftax-Classic-v1
+      obs: symbolic
+      seed: 7

--- a/rl_games/configs/playground/ppo_panda_pick_pixels.yaml
+++ b/rl_games/configs/playground/ppo_panda_pick_pixels.yaml
@@ -1,0 +1,96 @@
+# mujoco_playground PandaPickCubeCartesian from 64x64 PIXELS — pixel STUDENT
+# trained from scratch (CNN), no teacher. Baseline for ppo_panda_pick_pixels_distill.yaml.
+# ~5.8k env-steps/s at 1024 worlds (physics-bound).
+#
+#   LD_LIBRARY_PATH=/usr/lib/wsl/lib python scripts/playground_train.py -f rl_games/configs/playground/ppo_panda_pick_pixels.yaml
+params:
+  seed: 7
+
+  algo:
+    name: a2c_continuous
+
+  model:
+    name: continuous_a2c_logstd
+
+  network:
+    name: actor_critic
+    separate: False
+    space:
+      continuous:
+        mu_activation: None
+        sigma_activation: None
+        mu_init:
+          name: default
+        sigma_init:
+          name: const_initializer
+          val: -1.0
+        fixed_sigma: True
+    cnn:
+      permute_input: True        # obs arrives (B, H, W, C) uint8
+      type: conv2d
+      activation: elu
+      initializer:
+        name: default
+      regularizer:
+        name: None
+      convs:
+        - filters: 32
+          kernel_size: 5
+          strides: 2
+          padding: 0
+        - filters: 64
+          kernel_size: 3
+          strides: 2
+          padding: 0
+        - filters: 64
+          kernel_size: 3
+          strides: 1
+          padding: 0
+    mlp:
+      units: [256, 128]
+      activation: elu
+      initializer:
+        name: default
+  config:
+    name: panda_pick_pixels
+    env_name: playground
+    device: cuda
+
+    reward_shaper:
+      scale_value: 1.0
+
+    normalize_advantage: True
+    normalize_input: False     # uint8 pixels are scaled by 1/255 in _preproc_obs
+    normalize_value: True
+    value_bootstrap: True
+
+    gamma: 0.97
+    tau: 0.95
+    learning_rate: 3.0e-4
+    lr_schedule: adaptive
+    kl_threshold: 0.01
+
+    grad_norm: 1.0
+    truncate_grads: True
+    e_clip: 0.2
+    entropy_coef: 0.001
+    critic_coef: 1.0
+    bounds_loss_coef: 0.0001
+    clip_value: True
+
+    num_actors: 1024
+    horizon_length: 32
+    minibatch_size: 8192
+    mini_epochs: 4
+
+    max_epochs: 300
+    save_best_after: 20
+    save_frequency: 50
+    score_to_win: 100000
+    games_to_track: 500
+
+    env_config:
+      env_name: PandaPickCubeCartesian
+      obs: pixels
+      cam_res: [64, 64]
+      seed: 7

--- a/rl_games/configs/playground/ppo_panda_pick_pixels_distill.yaml
+++ b/rl_games/configs/playground/ppo_panda_pick_pixels_distill.yaml
@@ -1,0 +1,126 @@
+# mujoco_playground PandaPickCubeCartesian: 64x64 PIXEL student DISTILLED from
+# the 66-d state teacher (ppo_panda_pick_state.yaml). Env returns
+# {'obs': pixels, 'states': state}; the teacher and the central value net
+# consume states; the central value net is the teacher's MLP, warm-started.
+# Continuous actions: KL between the diagonal Gaussians.
+#
+# Schedule (epochs): 0-60 pure DAgger (ppo_coef 0, beta 0.5 -> 0 by 30),
+# 60-150 PPO fine-tune with the KL fading to 0, then PPO alone.
+#
+#   LD_LIBRARY_PATH=/usr/lib/wsl/lib python scripts/playground_train.py -f rl_games/configs/playground/ppo_panda_pick_pixels_distill.yaml
+params:
+  seed: 7
+
+  algo:
+    name: a2c_continuous
+
+  model:
+    name: continuous_a2c_logstd
+
+  network:
+    name: actor_critic
+    separate: False
+    space:
+      continuous:
+        mu_activation: None
+        sigma_activation: None
+        mu_init:
+          name: default
+        sigma_init:
+          name: const_initializer
+          val: -1.0
+        fixed_sigma: True
+    cnn:
+      permute_input: True        # obs arrives (B, H, W, C) uint8
+      type: conv2d
+      activation: elu
+      initializer:
+        name: default
+      regularizer:
+        name: None
+      convs:
+        - filters: 32
+          kernel_size: 5
+          strides: 2
+          padding: 0
+        - filters: 64
+          kernel_size: 3
+          strides: 2
+          padding: 0
+        - filters: 64
+          kernel_size: 3
+          strides: 1
+          padding: 0
+    mlp:
+      units: [256, 128]
+      activation: elu
+      initializer:
+        name: default
+  config:
+    name: panda_pick_pixels_distill
+    env_name: playground
+    device: cuda
+
+    reward_shaper:
+      scale_value: 1.0
+
+    normalize_advantage: True
+    normalize_input: False     # uint8 pixels are scaled by 1/255 in _preproc_obs
+    normalize_value: True
+    value_bootstrap: True
+
+    gamma: 0.97
+    tau: 0.95
+    learning_rate: 3.0e-4
+    lr_schedule: adaptive
+    kl_threshold: 0.01
+
+    grad_norm: 1.0
+    truncate_grads: True
+    e_clip: 0.2
+    entropy_coef: 0.001
+    critic_coef: 1.0
+    bounds_loss_coef: 0.0001
+    clip_value: True
+
+    num_actors: 1024
+    horizon_length: 32
+    minibatch_size: 8192
+    mini_epochs: 4
+
+    max_epochs: 300
+    save_best_after: 20
+    save_frequency: 50
+    score_to_win: 100000
+    games_to_track: 500
+
+    central_value_config:
+      minibatch_size: 8192
+      mini_epochs: 4
+      learning_rate: 3.0e-4
+      clip_value: True
+      normalize_input: True
+      truncate_grads: True
+      network:
+        name: actor_critic
+        central_value: True
+        mlp:
+          units: [256, 256, 256]
+          activation: elu
+          initializer:
+            name: default
+
+    distillation:
+      teacher_config: rl_games/configs/playground/ppo_panda_pick_state.yaml
+      teacher_checkpoint: runs/panda_teacher/nn/panda_pick_state.pth
+      loss: kl
+      coef: [[0, 1.0], [60, 1.0], [150, 0.0]]
+      ppo_coef: [[0, 0.0], [60, 0.0], [61, 1.0]]
+      beta: [[0, 0.5], [30, 0.0]]
+      warm_start_value: True
+
+    env_config:
+      env_name: PandaPickCubeCartesian
+      obs: both
+      cam_res: [64, 64]
+      seed: 7

--- a/rl_games/configs/playground/ppo_panda_pick_pixels_distill.yaml
+++ b/rl_games/configs/playground/ppo_panda_pick_pixels_distill.yaml
@@ -5,7 +5,13 @@
 # Continuous actions: KL between the diagonal Gaussians.
 #
 # Schedule (epochs): 0-60 pure DAgger (ppo_coef 0, beta 0.5 -> 0 by 30),
-# 60-150 PPO fine-tune with the KL fading to 0, then PPO alone.
+# 60-150 PPO fine-tune with the distillation term fading to 0, then PPO alone.
+#
+# v1 of this config failed (KL loss, adaptive lr): the distillation term makes
+# consecutive policies differ by far more than kl_threshold, so the adaptive
+# schedule drove lr to 5e-6 from epoch 1, and the teacher's unbounded means
+# (+-3, env clips at +-1) were unreachable targets that fought the bounds loss.
+# v2: mse on the teacher's means clamped to +-1, fixed lr.
 #
 #   LD_LIBRARY_PATH=/usr/lib/wsl/lib python scripts/playground_train.py -f rl_games/configs/playground/ppo_panda_pick_pixels_distill.yaml
 params:
@@ -72,7 +78,7 @@ params:
     gamma: 0.97
     tau: 0.95
     learning_rate: 3.0e-4
-    lr_schedule: adaptive
+    lr_schedule: fixed          # adaptive lr collapses under the distillation term
     kl_threshold: 0.01
 
     grad_norm: 1.0
@@ -113,7 +119,8 @@ params:
     distillation:
       teacher_config: rl_games/configs/playground/ppo_panda_pick_state.yaml
       teacher_checkpoint: runs/panda_pick_state_05-16-08-49/nn/panda_pick_state.pth
-      loss: kl
+      loss: mse
+      teacher_mu_clip: 1.0
       coef: [[0, 1.0], [60, 1.0], [150, 0.0]]
       ppo_coef: [[0, 0.0], [60, 0.0], [61, 1.0]]
       beta: [[0, 0.5], [30, 0.0]]

--- a/rl_games/configs/playground/ppo_panda_pick_pixels_distill.yaml
+++ b/rl_games/configs/playground/ppo_panda_pick_pixels_distill.yaml
@@ -112,7 +112,7 @@ params:
 
     distillation:
       teacher_config: rl_games/configs/playground/ppo_panda_pick_state.yaml
-      teacher_checkpoint: runs/panda_teacher/nn/panda_pick_state.pth
+      teacher_checkpoint: runs/panda_pick_state_05-16-08-49/nn/panda_pick_state.pth
       loss: kl
       coef: [[0, 1.0], [60, 1.0], [150, 0.0]]
       ppo_coef: [[0, 0.0], [60, 0.0], [61, 1.0]]

--- a/rl_games/configs/playground/ppo_panda_pick_pixels_stateaux.yaml
+++ b/rl_games/configs/playground/ppo_panda_pick_pixels_stateaux.yaml
@@ -1,0 +1,103 @@
+# mujoco_playground PandaPickCubeCartesian from 64x64 PIXELS, trained from
+# scratch WITH an auxiliary loss that regresses the privileged 66-d state from
+# the CNN trunk (actor_critic_state_aux). No teacher: the privileged
+# information is a prediction target only. Third arm next to
+# ppo_panda_pick_pixels_stateaux.yaml (scratch) and ppo_panda_pick_pixels_distill.yaml.
+#
+#   LD_LIBRARY_PATH=/usr/lib/wsl/lib python scripts/playground_train.py -f rl_games/configs/playground/ppo_panda_pick_pixels_stateaux.yaml
+params:
+  seed: 7
+
+  algo:
+    name: a2c_continuous
+
+  model:
+    name: continuous_a2c_logstd
+
+  network:
+    name: actor_critic_state_aux
+    separate: False
+    state_aux:
+      coef: 1.0
+      units: [256]
+    space:
+      continuous:
+        mu_activation: None
+        sigma_activation: None
+        mu_init:
+          name: default
+        sigma_init:
+          name: const_initializer
+          val: -1.0
+        fixed_sigma: True
+    cnn:
+      permute_input: True        # obs arrives (B, H, W, C) uint8
+      type: conv2d
+      activation: elu
+      initializer:
+        name: default
+      regularizer:
+        name: None
+      convs:
+        - filters: 32
+          kernel_size: 5
+          strides: 2
+          padding: 0
+        - filters: 64
+          kernel_size: 3
+          strides: 2
+          padding: 0
+        - filters: 64
+          kernel_size: 3
+          strides: 1
+          padding: 0
+    mlp:
+      units: [256, 128]
+      activation: elu
+      initializer:
+        name: default
+  config:
+    name: panda_pick_pixels_stateaux
+    env_name: playground
+    device: cuda
+
+    reward_shaper:
+      scale_value: 1.0
+
+    normalize_advantage: True
+    normalize_input: False     # uint8 pixels are scaled by 1/255 in _preproc_obs
+    normalize_value: True
+    value_bootstrap: True
+
+    gamma: 0.97
+    tau: 0.95
+    learning_rate: 3.0e-4
+    lr_schedule: adaptive
+    kl_threshold: 0.01
+
+    grad_norm: 1.0
+    truncate_grads: True
+    e_clip: 0.2
+    entropy_coef: 0.001
+    critic_coef: 1.0
+    bounds_loss_coef: 0.0001
+    clip_value: True
+
+    num_actors: 1024
+    horizon_length: 32
+    minibatch_size: 8192
+    mini_epochs: 4
+
+    max_epochs: 300
+    save_best_after: 20
+    save_frequency: 50
+    score_to_win: 100000
+    games_to_track: 500
+
+    state_aux: {}                # store states for the auxiliary head
+
+    env_config:
+      env_name: PandaPickCubeCartesian
+      obs: both
+      cam_res: [64, 64]
+      seed: 7

--- a/rl_games/configs/playground/ppo_panda_pick_state.yaml
+++ b/rl_games/configs/playground/ppo_panda_pick_state.yaml
@@ -1,0 +1,76 @@
+# mujoco_playground PandaPickCubeCartesian, privileged 66-d STATE — the TEACHER
+# for the pixel student (rl_games/common/distillation.py). Continuous PPO,
+# MLP. 1024 worlds on GPU (MJX + Warp), ~6.7k env-steps/s; 300 epochs x 32768
+# frames = ~10M frames (~25 min).
+#
+#   LD_LIBRARY_PATH=/usr/lib/wsl/lib python scripts/playground_train.py -f rl_games/configs/playground/ppo_panda_pick_state.yaml
+params:
+  seed: 7
+
+  algo:
+    name: a2c_continuous
+
+  model:
+    name: continuous_a2c_logstd
+
+  network:
+    name: actor_critic
+    separate: False
+    space:
+      continuous:
+        mu_activation: None
+        sigma_activation: None
+        mu_init:
+          name: default
+        sigma_init:
+          name: const_initializer
+          val: -1.0
+        fixed_sigma: True
+    mlp:
+      units: [256, 256, 256]
+      activation: elu
+      initializer:
+        name: default
+
+  config:
+    name: panda_pick_state
+    env_name: playground
+    device: cuda
+
+    reward_shaper:
+      scale_value: 1.0
+
+    normalize_advantage: True
+    normalize_input: True
+    normalize_value: True
+    value_bootstrap: True
+
+    gamma: 0.97
+    tau: 0.95
+    learning_rate: 3.0e-4
+    lr_schedule: adaptive
+    kl_threshold: 0.01
+
+    grad_norm: 1.0
+    truncate_grads: True
+    e_clip: 0.2
+    entropy_coef: 0.001
+    critic_coef: 1.0
+    bounds_loss_coef: 0.0001
+    clip_value: True
+
+    num_actors: 1024
+    horizon_length: 32
+    minibatch_size: 8192
+    mini_epochs: 4
+
+    max_epochs: 300
+    save_best_after: 20
+    save_frequency: 50
+    score_to_win: 100000
+    games_to_track: 500
+
+    env_config:
+      env_name: PandaPickCubeCartesian
+      obs: state
+      seed: 7

--- a/rl_games/envs/craftax_vecenv.py
+++ b/rl_games/envs/craftax_vecenv.py
@@ -1,0 +1,187 @@
+"""Craftax (Crafter in JAX) for rl_games, with privileged symbolic states.
+
+Craftax renders one game state two ways: a 1345-d symbolic vector and a
+63x63x3 pixel image (Craftax-Classic). This env returns
+
+  obs: symbolic  -> float32 (N, 1345)
+  obs: pixels    -> uint8   (N, 63, 63, 3)
+  obs: both      -> {'obs': uint8 pixels, 'states': float32 symbolic}
+
+so a symbolic teacher and a pixel student see the same states (see
+rl_games/common/distillation.py). Steps run under jax.jit with craftax's
+auto-reset (same-step: the obs returned on done is the new episode's first
+obs); tensors reach torch via dlpack. ~90k env-steps/s for 1024 envs on GPU.
+
+Infos on any done: `achievements` (N, 22) float32 of the finished episodes
+(rows of unfinished envs are stale and must be masked with `done_mask`).
+CraftaxObserver logs achievement rates and the Crafter score.
+"""
+
+import gymnasium as gym
+import numpy as np
+import torch
+
+from rl_games.common.algo_observer import AlgoObserver
+from rl_games.common.ivecenv import IVecEnv
+
+ACHIEVEMENTS = [
+    'collect_coal', 'collect_diamond', 'collect_drink', 'collect_iron', 'collect_sapling', 'collect_stone',
+    'collect_wood', 'defeat_skeleton', 'defeat_zombie', 'eat_cow', 'eat_plant', 'make_iron_pickaxe',
+    'make_iron_sword', 'make_stone_pickaxe', 'make_stone_sword', 'make_wood_pickaxe', 'make_wood_sword',
+    'place_furnace', 'place_plant', 'place_stone', 'place_table', 'wake_up',
+]
+
+
+def crafter_score(rates):
+    """Crafter score: geometric mean of achievement success rates (in %)."""
+    rates = np.asarray(rates, dtype=np.float64)
+    return float(np.exp(np.mean(np.log(1.0 + rates * 100.0))) - 1.0)
+
+
+class CraftaxVecEnv(IVecEnv):
+    def __init__(self, config_name, num_actors, **kwargs):
+        import jax
+        import jax.numpy as jnp
+        from craftax.craftax_env import make_craftax_env_from_name
+
+        self.num_envs = int(num_actors)
+        self.game = kwargs.pop('game', 'Craftax-Classic-v1')
+        self.obs_mode = kwargs.pop('obs', 'both')
+        if self.obs_mode not in ('symbolic', 'pixels', 'both'):
+            raise ValueError(f'obs must be symbolic | pixels | both, got {self.obs_mode!r}')
+        self.device = kwargs.pop('device', 'cuda' if torch.cuda.is_available() else 'cpu')
+        seed = int(kwargs.pop('seed', 0))
+        if self.game != 'Craftax-Classic-v1':
+            raise NotImplementedError('only Craftax-Classic-v1 is wired up (pixel renderer + 1345-d symbolic)')
+        from craftax.craftax_classic.constants import BLOCK_PIXEL_SIZE_AGENT
+        from craftax.craftax_classic.renderer import make_craftax_pixel_renderer, render_craftax_symbolic
+
+        self._jax, self._jnp = jax, jnp
+        env = make_craftax_env_from_name('Craftax-Classic-Symbolic-v1', auto_reset=True)
+        params = env.default_params
+        if 'max_timesteps' in kwargs:
+            params = params.replace(max_timesteps=int(kwargs.pop('max_timesteps')))
+        self.params = params
+        self.env = env
+        self.actions_num = env.action_space(params).n
+        render_pixels = make_craftax_pixel_renderer(BLOCK_PIXEL_SIZE_AGENT)
+        want_pix = self.obs_mode in ('pixels', 'both')
+        want_sym = self.obs_mode in ('symbolic', 'both')
+        ach_keys = ['Achievements/' + a for a in ACHIEVEMENTS]
+
+        def _outputs(state):
+            pix = render_pixels(state).astype(jnp.uint8) if want_pix else None
+            sym = render_craftax_symbolic(state) if want_sym else None
+            return pix, sym
+
+        def _reset(key):
+            keys = jax.random.split(key, self.num_envs)
+            _, state = jax.vmap(env.reset, in_axes=(0, None))(keys, params)
+            pix, sym = jax.vmap(_outputs)(state)
+            return state, pix, sym
+
+        def _step(key, state, actions):
+            keys = jax.random.split(key, self.num_envs)
+            _, state, reward, done, info = jax.vmap(env.step, in_axes=(0, 0, 0, None))(keys, state, actions, params)
+            pix, sym = jax.vmap(_outputs)(state)
+            ach = jnp.stack([info[k] for k in ach_keys], axis=1).astype(jnp.float32)
+            return state, pix, sym, reward.astype(jnp.float32), done, ach
+
+        self._reset_fn = jax.jit(_reset)
+        self._step_fn = jax.jit(_step)
+        self._key = jax.random.PRNGKey(seed)
+        self._state = None
+        self._dlpack_ok = True
+
+        self.pixel_space = gym.spaces.Box(0, 255, shape=(63, 63, 3), dtype=np.uint8)
+        self.state_space = gym.spaces.Box(-np.inf, np.inf, shape=(1345,), dtype=np.float32)
+        self.observation_space = self.pixel_space if want_pix else self.state_space
+        self.action_space = gym.spaces.Discrete(self.actions_num)
+
+    # ------------------------------------------------------------ bridging
+
+    def _to_torch(self, x):
+        if x is None:
+            return None
+        if self._dlpack_ok:
+            try:
+                return torch.from_dlpack(x).to(self.device)
+            except Exception:
+                self._dlpack_ok = False
+        return torch.as_tensor(np.asarray(x)).to(self.device)
+
+    def _to_jax(self, t):
+        t = t.detach().to(torch.int32).contiguous()
+        try:
+            return self._jax.dlpack.from_dlpack(t)
+        except Exception:
+            return self._jnp.asarray(t.cpu().numpy())
+
+    def _pack(self, pix, sym):
+        if self.obs_mode == 'both':
+            return {'obs': self._to_torch(pix), 'states': self._to_torch(sym)}
+        return self._to_torch(pix if self.obs_mode == 'pixels' else sym)
+
+    def _next_key(self):
+        self._key, sub = self._jax.random.split(self._key)
+        return sub
+
+    # ------------------------------------------------------------- IVecEnv
+
+    def reset(self):
+        self._state, pix, sym = self._reset_fn(self._next_key())
+        return self._pack(pix, sym)
+
+    def step(self, actions):
+        if not torch.is_tensor(actions):
+            actions = torch.as_tensor(np.asarray(actions))
+        acts = self._to_jax(actions.reshape(self.num_envs))
+        self._state, pix, sym, reward, done, ach = self._step_fn(self._next_key(), self._state, acts)
+        rewards = self._to_torch(reward)
+        dones = self._to_torch(done).bool()
+        infos = {}
+        if bool(dones.any()):
+            infos['achievements'] = self._to_torch(ach)
+            infos['done_mask'] = dones
+        return self._pack(pix, sym), rewards, dones, infos
+
+    def get_number_of_agents(self):
+        return 1
+
+    def get_env_info(self):
+        return {'observation_space': self.observation_space, 'state_space': self.state_space,
+                'action_space': self.action_space, 'agents': 1, 'value_size': 1}
+
+
+class CraftaxObserver(AlgoObserver):
+    """Logs craftax/score (Crafter score) and craftax/ach_<name> success rates
+    over the last `window` finished episodes."""
+
+    def __init__(self, window=1000):
+        super().__init__()
+        self.window = window
+        self.episodes = []
+        self.writer = None
+
+    def after_init(self, algo):
+        self.algo = algo
+        self.writer = getattr(algo, 'writer', None)
+
+    def process_infos(self, infos, done_indices):
+        if not isinstance(infos, dict) or 'achievements' not in infos:
+            return
+        ach = infos['achievements'][infos['done_mask']].cpu().numpy()
+        self.episodes.extend(list(ach))
+        self.episodes = self.episodes[-self.window:]
+
+    def rates(self):
+        return np.mean(np.stack(self.episodes), axis=0) if self.episodes else np.zeros(len(ACHIEVEMENTS))
+
+    def after_print_stats(self, frame, epoch_num, total_time):
+        if self.writer is None or not self.episodes:
+            return
+        r = self.rates()
+        self.writer.add_scalar('craftax/score', crafter_score(r), frame)
+        self.writer.add_scalar('craftax/episodes_in_window', len(self.episodes), frame)
+        for name, v in zip(ACHIEVEMENTS, r):
+            self.writer.add_scalar(f'craftax/ach_{name}', float(v), frame)

--- a/rl_games/envs/craftax_vecenv.py
+++ b/rl_games/envs/craftax_vecenv.py
@@ -84,7 +84,8 @@ class CraftaxVecEnv(IVecEnv):
             keys = jax.random.split(key, self.num_envs)
             _, state, reward, done, info = jax.vmap(env.step, in_axes=(0, 0, 0, None))(keys, state, actions, params)
             pix, sym = jax.vmap(_outputs)(state)
-            ach = jnp.stack([info[k] for k in ach_keys], axis=1).astype(jnp.float32)
+            # craftax reports achievements as 0/100 percentages; keep 0/1
+            ach = jnp.stack([info[k] for k in ach_keys], axis=1).astype(jnp.float32) / 100.0
             return state, pix, sym, reward.astype(jnp.float32), done, ach
 
         self._reset_fn = jax.jit(_reset)

--- a/rl_games/envs/playground_vecenv.py
+++ b/rl_games/envs/playground_vecenv.py
@@ -77,6 +77,8 @@ class PlaygroundVecEnv(IVecEnv):
                                              action_repeat=int(cfg.action_repeat), full_reset=full_reset)
         self._jax, self._jnp = jax, jnp
         self.action_size = int(env.action_size)
+        self.raw_env = raw                          # unwrapped playground env (render, mj_model)
+        self.cfg = cfg
         self._jax_gpu = jax.default_backend() == 'gpu'
         get_state = getattr(raw, '_get_obs', None)
         if get_state is None and self.obs_mode != 'state':
@@ -176,6 +178,14 @@ class PlaygroundVecEnv(IVecEnv):
             infos['metrics'] = {k: self._to_torch(v).float() for k, v in metrics.items()}
             infos['done_mask'] = dones
         return self._pack(pix, state), rewards, dones, infos
+
+    def env_state(self, index):
+        """Unbatched playground State of world `index` (for raw_env.render)."""
+        n = self.num_envs
+
+        def pick(x):
+            return x[index] if getattr(x, 'ndim', 0) > 0 and x.shape[0] == n else x
+        return self._jax.tree_util.tree_map(pick, self._state)
 
     def get_number_of_agents(self):
         return 1

--- a/rl_games/envs/playground_vecenv.py
+++ b/rl_games/envs/playground_vecenv.py
@@ -1,0 +1,224 @@
+"""mujoco_playground (MJX + Warp physics, built-in batch renderer) for rl_games.
+
+Any playground env (manipulation / dm_control_suite / locomotion) with
+
+  obs: state   -> float32 (N, state_dim)          the env's privileged state vector
+  obs: pixels  -> uint8   (N, H, W, 3)            camera 0 of the built-in renderer
+  obs: both    -> {'obs': uint8 pixels, 'states': float32 state}
+
+so a state teacher and a pixel student see the same physics state (see
+rl_games/common/distillation.py). The state vector is the env's own
+`_get_obs(data, info)` (e.g. 66-d for PandaPickCubeCartesian, 5-d for
+CartpoleBalance), computed from the same `data` the pixels are rendered
+from, so it is identical in every obs mode.
+
+Episodes: brax EpisodeWrapper (time limit -> `time_outs`) + AutoReset with
+`full_reset=True` (a fresh random reset on done). Steps are jitted; tensors
+reach torch via dlpack. Measured on an RTX 5090 at 1024 worlds:
+PandaPickCubeCartesian 6.7k steps/s (state) / 5.8k (64x64 pixels),
+CartpoleBalance 393k / 72k.
+
+WSL2: Warp needs the driver's libcuda from /usr/lib/wsl/lib; it is preloaded
+here (equivalent to LD_LIBRARY_PATH=/usr/lib/wsl/lib). Requires playground
+0.2, mujoco 3.12 and warp-lang 1.16 (1.17 breaks mujoco's vendored JAX FFI).
+"""
+
+import ctypes
+import os
+
+import gymnasium as gym
+import numpy as np
+import torch
+
+from rl_games.common.algo_observer import AlgoObserver
+from rl_games.common.ivecenv import IVecEnv
+
+
+def _preload_wsl_cuda():
+    p = '/usr/lib/wsl/lib/libcuda.so.1'
+    if os.path.exists(p):
+        try:
+            ctypes.CDLL(p, mode=ctypes.RTLD_GLOBAL)
+        except OSError:
+            pass
+
+
+class PlaygroundVecEnv(IVecEnv):
+    def __init__(self, config_name, num_actors, **kwargs):
+        _preload_wsl_cuda()
+        import jax
+        import jax.numpy as jnp
+        from mujoco_playground import registry, wrapper
+
+        self.num_envs = int(num_actors)
+        self.env_name = kwargs.pop('env_name', 'PandaPickCubeCartesian')
+        self.obs_mode = kwargs.pop('obs', 'state')
+        if self.obs_mode not in ('state', 'pixels', 'both'):
+            raise ValueError(f'obs must be state | pixels | both, got {self.obs_mode!r}')
+        self.device = kwargs.pop('device', 'cuda' if torch.cuda.is_available() else 'cpu')
+        seed = int(kwargs.pop('seed', 0))
+        cam_res = tuple(int(x) for x in kwargs.pop('cam_res', (64, 64)))
+        full_reset = bool(kwargs.pop('full_reset', True))
+        overrides = kwargs.pop('config_overrides', None) or {}
+        vision = self.obs_mode in ('pixels', 'both')
+
+        cfg = registry.get_default_config(self.env_name)
+        for k, v in overrides.items():
+            cfg[k] = v
+        if hasattr(cfg, 'vision'):
+            cfg.vision = vision
+            if vision:
+                cfg.vision_config.nworld = self.num_envs
+                cfg.vision_config.cam_res = cam_res
+        elif vision:
+            raise ValueError(f'{self.env_name} has no vision config')
+        raw = registry.load(self.env_name, config=cfg)
+        env = wrapper.wrap_for_brax_training(raw, episode_length=int(cfg.episode_length),
+                                             action_repeat=int(cfg.action_repeat), full_reset=full_reset)
+        self._jax, self._jnp = jax, jnp
+        self.action_size = int(env.action_size)
+        self._jax_gpu = jax.default_backend() == 'gpu'
+        get_state = getattr(raw, '_get_obs', None)
+        if get_state is None and self.obs_mode != 'state':
+            raise ValueError(f'{self.env_name} has no _get_obs(data, info); only obs: state is possible')
+
+        def _outputs(st):
+            state = jax.vmap(get_state)(st.data, st.info) if get_state is not None else st.obs
+            pix = None
+            if vision:
+                p = st.obs['pixels/view_0'] if isinstance(st.obs, dict) else st.obs
+                pix = jnp.clip(p * 255.0, 0, 255).astype(jnp.uint8)
+            return pix, state
+
+        def _reset(key):
+            st = env.reset(jax.random.split(key, self.num_envs))
+            return st, _outputs(st)
+
+        episode_length = int(cfg.episode_length)
+
+        def _step(st, act):
+            st = env.step(st, act)
+            pix, state = _outputs(st)
+            metrics = {k: v for k, v in st.metrics.items()}
+            # the auto-reset wrapper replaces info of done envs with the fresh
+            # episode's, losing EpisodeWrapper's `truncation`; `steps` survives
+            done = st.done.astype(bool)
+            trunc = done & (st.info['steps'] >= episode_length)
+            return st, pix, state, st.reward, done, trunc, metrics
+
+        self._reset_fn = jax.jit(_reset)
+        self._step_fn = jax.jit(_step)
+        self._key = jax.random.PRNGKey(seed)
+        self._state = None
+        self._dlpack_ok = True
+
+        # spaces (state dim from a probe reset)
+        st, (pix, state) = self._reset_fn(self._next_key())
+        self._state = st
+        self.state_dim = int(state.shape[-1])
+        self.state_space = gym.spaces.Box(-np.inf, np.inf, shape=(self.state_dim,), dtype=np.float32)
+        self.pixel_space = gym.spaces.Box(0, 255, shape=(cam_res[0], cam_res[1], 3), dtype=np.uint8)
+        self.observation_space = self.pixel_space if vision else self.state_space
+        self.action_space = gym.spaces.Box(-1.0, 1.0, shape=(self.action_size,), dtype=np.float32)
+        self._first = (pix, state)
+
+    # ------------------------------------------------------------ bridging
+
+    def _to_torch(self, x):
+        if x is None:
+            return None
+        if self._dlpack_ok:
+            try:
+                return torch.from_dlpack(x).to(self.device)
+            except Exception:
+                self._dlpack_ok = False
+        return torch.as_tensor(np.asarray(x)).to(self.device)
+
+    def _to_jax(self, t):
+        t = t.detach().float().clamp(-1.0, 1.0).contiguous()
+        if self._jax_gpu and t.device.type != 'cuda':
+            # a CPU-committed dlpack array would pull the whole jitted step
+            # onto the JAX CPU backend, where the Warp FFI cannot run
+            t = t.cuda()
+        try:
+            return self._jax.dlpack.from_dlpack(t)
+        except Exception:
+            return self._jnp.asarray(t.cpu().numpy())
+
+    def _pack(self, pix, state):
+        if self.obs_mode == 'both':
+            return {'obs': self._to_torch(pix), 'states': self._to_torch(state).float()}
+        return self._to_torch(pix) if self.obs_mode == 'pixels' else self._to_torch(state).float()
+
+    def _next_key(self):
+        self._key, sub = self._jax.random.split(self._key)
+        return sub
+
+    # ------------------------------------------------------------- IVecEnv
+
+    def reset(self):
+        if self._first is not None:                 # use the probe reset once
+            pix, state = self._first
+            self._first = None
+        else:
+            self._state, (pix, state) = self._reset_fn(self._next_key())
+        return self._pack(pix, state)
+
+    def step(self, actions):
+        if not torch.is_tensor(actions):
+            actions = torch.as_tensor(np.asarray(actions))
+        acts = self._to_jax(actions.reshape(self.num_envs, self.action_size))
+        self._state, pix, state, reward, done, trunc, metrics = self._step_fn(self._state, acts)
+        rewards = self._to_torch(reward).float()
+        dones = self._to_torch(done).bool()
+        infos = {'time_outs': self._to_torch(trunc).bool()}
+        if bool(dones.any()):
+            infos['metrics'] = {k: self._to_torch(v).float() for k, v in metrics.items()}
+            infos['done_mask'] = dones
+        return self._pack(pix, state), rewards, dones, infos
+
+    def get_number_of_agents(self):
+        return 1
+
+    def get_env_info(self):
+        return {'observation_space': self.observation_space, 'state_space': self.state_space,
+                'action_space': self.action_space, 'agents': 1, 'value_size': 1}
+
+
+class PlaygroundObserver(AlgoObserver):
+    """Logs the mean of every env metric (e.g. reward/success, out_of_bounds)
+    over the last `window` finished episodes as playground/<metric>."""
+
+    def __init__(self, window=1000):
+        super().__init__()
+        self.window = window
+        self.episodes = []
+        self.keys = None
+        self.writer = None
+
+    def after_init(self, algo):
+        self.algo = algo
+        self.writer = getattr(algo, 'writer', None)
+
+    def process_infos(self, infos, done_indices):
+        if not isinstance(infos, dict) or 'metrics' not in infos:
+            return
+        mask = infos['done_mask']
+        keys = sorted(infos['metrics'])
+        if self.keys is None:
+            self.keys = keys
+        rows = torch.stack([infos['metrics'][k][mask] for k in self.keys], dim=1).cpu().numpy()
+        self.episodes.extend(list(rows))
+        self.episodes = self.episodes[-self.window:]
+
+    def means(self):
+        if not self.episodes:
+            return {}
+        m = np.mean(np.stack(self.episodes), axis=0)
+        return {k: float(v) for k, v in zip(self.keys, m)}
+
+    def after_print_stats(self, frame, epoch_num, total_time):
+        if self.writer is None:
+            return
+        for k, v in self.means().items():
+            self.writer.add_scalar(f'playground/{k}', v, frame)

--- a/scripts/craftax_play.py
+++ b/scripts/craftax_play.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python
+"""Play Craftax-Classic with a pixel (or symbolic) checkpoint and record env 0 to mp4.
+
+    python scripts/craftax_play.py -f rl_games/configs/craftax/ppo_craftax_classic_pixels_distill.yaml \
+        -c runs/<run>/nn/craftax_classic_pixels_distill.pth --video craftax_distill.mp4
+"""
+import argparse, os, sys, time
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+import numpy as np, torch, yaml
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('-f', '--file', required=True)
+    ap.add_argument('-c', '--checkpoint', required=True)
+    ap.add_argument('--envs', type=int, default=16)
+    ap.add_argument('--max-steps', type=int, default=3000)
+    ap.add_argument('--video', default=None)
+    ap.add_argument('--fps', type=int, default=8)
+    ap.add_argument('--seed', type=int, default=123)
+    ap.add_argument('--deterministic', action='store_true')
+    args = ap.parse_args()
+
+    from rl_games.algos_torch.model_builder import ModelBuilder
+    from rl_games.envs.craftax_vecenv import CraftaxVecEnv, ACHIEVEMENTS, crafter_score
+    from craftax.craftax_classic.renderer import make_craftax_pixel_renderer
+    from craftax.craftax_classic.constants import BLOCK_PIXEL_SIZE_HUMAN
+    import jax
+
+    params = yaml.safe_load(open(args.file))['params']
+    cfg = params['config']
+    env_cfg = dict(cfg['env_config']); env_cfg.update(seed=args.seed)
+    env = CraftaxVecEnv('craftax', args.envs, **env_cfg)
+    info = env.get_env_info()
+    obs_space = info['observation_space']
+    net = ModelBuilder().load(params)
+    model = net.build({'actions_num': info['action_space'].n, 'input_shape': obs_space.shape, 'num_seqs': 1,
+                       'value_size': 1, 'normalize_value': cfg.get('normalize_value', False),
+                       'normalize_input': cfg.get('normalize_input', False)}).to(env.device).eval()
+    sd = torch.load(args.checkpoint, map_location=env.device, weights_only=False)['model']
+    sd = {k[len('_orig_mod.'):] if k.startswith('_orig_mod.') else k: v for k, v in sd.items()}
+    model.load_state_dict(sd)
+    render_big = jax.jit(make_craftax_pixel_renderer(BLOCK_PIXEL_SIZE_HUMAN))
+
+    def policy_obs(o):
+        o = o['obs'] if isinstance(o, dict) else o
+        return o.float() / 255.0 if o.dtype == torch.uint8 else o
+
+    obs = env.reset()
+    frames, finished, results = [], np.zeros(args.envs, dtype=bool), []
+    rewards = np.zeros(args.envs); lengths = np.zeros(args.envs, dtype=int)
+    t0 = time.time()
+    for step in range(args.max_steps):
+        with torch.no_grad():
+            out = model({'obs': policy_obs(obs), 'is_train': False})
+            act = out['logits'].argmax(-1) if args.deterministic else out['actions']
+        if args.video and not finished[0]:
+            state0 = jax.tree_util.tree_map(lambda x: x[0], env._state)
+            frames.append(np.asarray(render_big(state0)).astype(np.uint8))
+        obs, r, d, inf = env.step(act)
+        rewards += r.cpu().numpy() * (~finished); lengths += (~finished)
+        dm = d.cpu().numpy()
+        for i in np.nonzero(dm & ~finished)[0]:
+            results.append(inf['achievements'][i].cpu().numpy()); finished[i] = True
+        if finished.all():
+            break
+    print(f'{finished.sum()} episodes in {time.time() - t0:.1f}s; reward mean {rewards[finished].mean():.2f}, '
+          f'len mean {lengths[finished].mean():.0f}')
+    if results:
+        rates = np.mean(np.stack(results), axis=0)
+        print(f'crafter score {crafter_score(rates):.1f}; achievements:',
+              {a: round(float(v), 2) for a, v in zip(ACHIEVEMENTS, rates) if v > 0})
+    print(f'env 0: reward {rewards[0]:.1f}, length {lengths[0]}')
+    if args.video and frames:
+        import imageio
+        imageio.mimwrite(args.video, frames, fps=args.fps, quality=7)
+        print('video', args.video, len(frames), 'frames', frames[0].shape)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/craftax_train.py
+++ b/scripts/craftax_train.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+"""Train Craftax with the CraftaxObserver attached (craftax/score, achievement rates).
+
+    python scripts/craftax_train.py -f rl_games/configs/craftax/ppo_craftax_classic_symbolic.yaml
+    python scripts/craftax_train.py -f ... --max-epochs 500 --name probe --train-dir runs
+"""
+import argparse
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+import yaml
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('-f', '--file', required=True)
+    ap.add_argument('-c', '--checkpoint', default=None)
+    ap.add_argument('--max-epochs', type=int, default=0)
+    ap.add_argument('--name', default=None)
+    ap.add_argument('--train-dir', default=None)
+    ap.add_argument('--num-actors', type=int, default=0)
+    args = ap.parse_args()
+
+    with open(args.file) as f:
+        cfg = yaml.safe_load(f)
+    conf = cfg['params']['config']
+    if args.max_epochs > 0:
+        conf['max_epochs'] = args.max_epochs
+    if args.name:
+        conf['name'] = args.name
+    if args.train_dir:
+        conf['train_dir'] = args.train_dir
+    if args.num_actors > 0:
+        conf['num_actors'] = args.num_actors
+
+    from rl_games.torch_runner import Runner
+    from rl_games.envs.craftax_vecenv import CraftaxObserver
+    runner = Runner(CraftaxObserver())
+    runner.load(cfg)
+    runner.run({'train': True, 'play': False, 'checkpoint': args.checkpoint})
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/playground_play.py
+++ b/scripts/playground_play.py
@@ -12,6 +12,7 @@ import sys
 WSL_LIB = '/usr/lib/wsl/lib'
 if os.path.isdir(WSL_LIB) and WSL_LIB not in os.environ.get('LD_LIBRARY_PATH', '').split(':'):
     os.environ['LD_LIBRARY_PATH'] = WSL_LIB + (':' + os.environ['LD_LIBRARY_PATH'] if os.environ.get('LD_LIBRARY_PATH') else '')
+    os.environ.setdefault('PYTHONUNBUFFERED', '1')     # keep logs live after the re-exec
     os.execv(sys.executable, [sys.executable] + sys.argv)
 os.environ.setdefault('MUJOCO_GL', 'egl')
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))

--- a/scripts/playground_play.py
+++ b/scripts/playground_play.py
@@ -52,6 +52,8 @@ def main():
     mj = env.raw_env.mj_model
     cams = [mj.camera(i).name for i in range(mj.ncam)]
     camera = args.camera if args.camera is not None else (cams[0] if cams else None)
+    if camera == 'free':
+        camera = None                       # mujoco's default free camera
     print('cameras:', cams, '-> using', camera)
 
     def policy_obs(o):

--- a/scripts/playground_play.py
+++ b/scripts/playground_play.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python
+"""Play a mujoco_playground checkpoint and record world 0 to mp4 (big render
++ the policy's own pixel view as an inset when the obs is pixels).
+
+    python scripts/playground_play.py -f rl_games/configs/playground/ppo_panda_pick_pixels_distill.yaml \
+        -c runs/<run>/nn/panda_pick_pixels_distill.pth --video panda_distill.mp4 --episodes 3
+"""
+import argparse
+import os
+import sys
+
+WSL_LIB = '/usr/lib/wsl/lib'
+if os.path.isdir(WSL_LIB) and WSL_LIB not in os.environ.get('LD_LIBRARY_PATH', '').split(':'):
+    os.environ['LD_LIBRARY_PATH'] = WSL_LIB + (':' + os.environ['LD_LIBRARY_PATH'] if os.environ.get('LD_LIBRARY_PATH') else '')
+    os.execv(sys.executable, [sys.executable] + sys.argv)
+os.environ.setdefault('MUJOCO_GL', 'egl')
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+import numpy as np
+import torch
+import yaml
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('-f', '--file', required=True)
+    ap.add_argument('-c', '--checkpoint', required=True)
+    ap.add_argument('--envs', type=int, default=64)
+    ap.add_argument('--episodes', type=int, default=3, help='consecutive episodes of world 0 to film')
+    ap.add_argument('--video', default=None)
+    ap.add_argument('--camera', default=None)
+    ap.add_argument('--fps', type=int, default=20)
+    ap.add_argument('--seed', type=int, default=123)
+    ap.add_argument('--stochastic', action='store_true')
+    args = ap.parse_args()
+
+    from rl_games.algos_torch.model_builder import ModelBuilder
+    from rl_games.envs.playground_vecenv import PlaygroundVecEnv
+    params = yaml.safe_load(open(args.file))['params']
+    cfg = params['config']
+    env_cfg = dict(cfg['env_config'])
+    env_cfg.update(seed=args.seed)
+    env = PlaygroundVecEnv('playground', args.envs, **env_cfg)
+    info = env.get_env_info()
+    net = ModelBuilder().load(params)
+    model = net.build({'actions_num': info['action_space'].shape[0], 'input_shape': info['observation_space'].shape,
+                       'num_seqs': 1, 'value_size': 1, 'normalize_value': cfg.get('normalize_value', False),
+                       'normalize_input': cfg.get('normalize_input', False)}).to(env.device).eval()
+    sd = torch.load(args.checkpoint, map_location=env.device, weights_only=False)['model']
+    sd = {k[len('_orig_mod.'):] if k.startswith('_orig_mod.') else k: v for k, v in sd.items()}
+    model.load_state_dict(sd)
+    mj = env.raw_env.mj_model
+    cams = [mj.camera(i).name for i in range(mj.ncam)]
+    camera = args.camera if args.camera is not None else (cams[0] if cams else None)
+    print('cameras:', cams, '-> using', camera)
+
+    def policy_obs(o):
+        o = o['obs'] if isinstance(o, dict) else o
+        return o.float() / 255.0 if o.dtype == torch.uint8 else o
+
+    obs = env.reset()
+    traj, insets = [], []
+    successes, lengths, finished = [], [], 0
+    ep_len = np.zeros(args.envs, dtype=int)
+    while True:
+        if args.video:
+            traj.append(env.env_state(0))
+            o0 = obs['obs'][0] if isinstance(obs, dict) else obs[0]
+            if o0.dtype == torch.uint8:
+                insets.append(o0.cpu().numpy())
+        with torch.no_grad():
+            out = model({'obs': policy_obs(obs), 'is_train': False})
+            act = out['actions'] if args.stochastic else out['mus']
+        obs, r, d, inf = env.step(act)
+        ep_len += 1
+        if d.any():
+            m = inf['metrics']
+            for i in torch.nonzero(d).flatten().tolist():
+                successes.append(float(m['reward/success'][i]) if 'reward/success' in m else float('nan'))
+                lengths.append(int(ep_len[i]))
+                ep_len[i] = 0
+                if i == 0:
+                    finished += 1
+        if finished >= args.episodes or len(traj) > 400 * args.episodes:
+            break
+    print(f'{len(successes)} episodes: success rate {np.nanmean(successes):.2f}, mean length {np.mean(lengths):.0f}')
+    if args.video and traj:
+        import imageio
+        frames = env.raw_env.render(traj, height=480, width=640, camera=camera)
+        out = []
+        for k, fr in enumerate(frames):
+            fr = np.asarray(fr).copy()
+            if insets:
+                ins = np.kron(insets[k], np.ones((3, 3, 1), dtype=np.uint8))       # 64 -> 192 px
+                fr[8:8 + ins.shape[0], 8:8 + ins.shape[1]] = ins
+            out.append(fr)
+        imageio.mimwrite(args.video, out, fps=args.fps, quality=7)
+        print('video', args.video, len(out), 'frames', out[0].shape)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/playground_train.py
+++ b/scripts/playground_train.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python
+"""Train a mujoco_playground env with the PlaygroundObserver attached.
+
+    LD_LIBRARY_PATH=/usr/lib/wsl/lib python scripts/playground_train.py -f rl_games/configs/playground/ppo_panda_pick_state.yaml
+    ... --max-epochs 100 --name probe
+
+Under WSL2 the CUDA toolkit's stub libcuda shadows the driver's; Warp then
+reports no CUDA device. The script re-execs itself with
+LD_LIBRARY_PATH=/usr/lib/wsl/lib prepended when that directory exists.
+"""
+import argparse
+import os
+import sys
+
+WSL_LIB = '/usr/lib/wsl/lib'
+if os.path.isdir(WSL_LIB) and WSL_LIB not in os.environ.get('LD_LIBRARY_PATH', '').split(':'):
+    os.environ['LD_LIBRARY_PATH'] = WSL_LIB + (':' + os.environ['LD_LIBRARY_PATH'] if os.environ.get('LD_LIBRARY_PATH') else '')
+    os.execv(sys.executable, [sys.executable] + sys.argv)
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+import yaml
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('-f', '--file', required=True)
+    ap.add_argument('-c', '--checkpoint', default=None)
+    ap.add_argument('--max-epochs', type=int, default=0)
+    ap.add_argument('--name', default=None)
+    ap.add_argument('--train-dir', default=None)
+    ap.add_argument('--num-actors', type=int, default=0)
+    args = ap.parse_args()
+
+    with open(args.file) as f:
+        cfg = yaml.safe_load(f)
+    conf = cfg['params']['config']
+    if args.max_epochs > 0:
+        conf['max_epochs'] = args.max_epochs
+    if args.name:
+        conf['name'] = args.name
+    if args.train_dir:
+        conf['train_dir'] = args.train_dir
+    if args.num_actors > 0:
+        conf['num_actors'] = args.num_actors
+
+    from rl_games.torch_runner import Runner
+    from rl_games.envs.playground_vecenv import PlaygroundObserver
+    runner = Runner(PlaygroundObserver())
+    runner.load(cfg)
+    runner.run({'train': True, 'play': False, 'checkpoint': args.checkpoint})
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/playground_train.py
+++ b/scripts/playground_train.py
@@ -15,6 +15,7 @@ import sys
 WSL_LIB = '/usr/lib/wsl/lib'
 if os.path.isdir(WSL_LIB) and WSL_LIB not in os.environ.get('LD_LIBRARY_PATH', '').split(':'):
     os.environ['LD_LIBRARY_PATH'] = WSL_LIB + (':' + os.environ['LD_LIBRARY_PATH'] if os.environ.get('LD_LIBRARY_PATH') else '')
+    os.environ.setdefault('PYTHONUNBUFFERED', '1')     # keep logs live after the re-exec
     os.execv(sys.executable, [sys.executable] + sys.argv)
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))

--- a/tests/test_craftax_env.py
+++ b/tests/test_craftax_env.py
@@ -1,0 +1,117 @@
+"""Tests for the Craftax vec env (JAX, 3.11 venv) and the end-to-end
+distillation plumbing through the PPO agent."""
+
+import numpy as np
+import pytest
+import torch
+
+
+def _has_craftax():
+    try:
+        import craftax, jax  # noqa: F401
+        return True
+    except Exception:
+        return False
+
+
+needs_craftax = pytest.mark.skipif(not _has_craftax(), reason='craftax/jax unavailable')
+
+
+def _make(n=8, **kw):
+    from rl_games.envs.craftax_vecenv import CraftaxVecEnv
+    cfg = dict(game='Craftax-Classic-v1', obs='both', seed=1, device='cpu')
+    cfg.update(kw)
+    return CraftaxVecEnv('craftax', n, **cfg)
+
+
+@needs_craftax
+def test_both_mode_shapes_and_env_info():
+    env = _make(8)
+    info = env.get_env_info()
+    assert info['observation_space'].shape == (63, 63, 3) and info['observation_space'].dtype == np.uint8
+    assert info['state_space'].shape == (1345,)
+    assert info['action_space'].n == 17 and info['agents'] == 1
+    obs = env.reset()
+    assert obs['obs'].shape == (8, 63, 63, 3) and obs['obs'].dtype == torch.uint8
+    assert obs['states'].shape == (8, 1345) and obs['states'].dtype == torch.float32
+    assert int(obs['obs'].max()) > 0
+    o, r, d, inf = env.step(torch.randint(0, 17, (8,)))
+    assert o['obs'].shape == (8, 63, 63, 3) and r.shape == (8,) and d.shape == (8,) and d.dtype == torch.bool
+    assert r.dtype == torch.float32
+
+
+@needs_craftax
+def test_single_modes():
+    env = _make(4, obs='symbolic')
+    assert env.get_env_info()['observation_space'].shape == (1345,)
+    o = env.reset()
+    assert torch.is_tensor(o) and o.shape == (4, 1345)
+    env = _make(4, obs='pixels')
+    assert env.get_env_info()['observation_space'].shape == (63, 63, 3)
+    o = env.reset()
+    assert torch.is_tensor(o) and o.shape == (4, 63, 63, 3) and o.dtype == torch.uint8
+
+
+@needs_craftax
+def test_autoreset_and_achievements_info():
+    env = _make(4, max_timesteps=30)          # short episodes -> dones within 30 steps
+    env.reset()
+    seen = False
+    for t in range(40):
+        o, r, d, info = env.step(torch.randint(0, 17, (4,)))
+        assert o['obs'].shape == (4, 63, 63, 3)
+        if d.any():
+            seen = True
+            assert info['achievements'].shape == (4, 22)
+            assert torch.equal(info['done_mask'], d)
+    assert seen
+
+
+def test_craftax_observer_score():
+    from rl_games.envs.craftax_vecenv import CraftaxObserver, crafter_score
+    rates = np.zeros(22)
+    rates[:2] = 1.0            # two achievements always, rest never
+    expected = np.exp(np.mean(np.log(1 + rates * 100))) - 1
+    assert abs(crafter_score(rates) - expected) < 1e-9
+
+    class _Algo:
+        writer = None
+        num_agents = 1
+
+    obs = CraftaxObserver()
+    obs.after_init(_Algo())
+    ach = torch.zeros(4, 22)
+    ach[0, 3] = 1
+    ach[1, 3] = 1
+    obs.process_infos({'achievements': ach, 'done_mask': torch.tensor([True, True, False, False])},
+                      torch.tensor([[0], [1]]))
+    assert len(obs.episodes) == 2 and abs(obs.rates()[3] - 1.0) < 1e-9 and obs.rates()[0] == 0.0
+
+
+@needs_craftax
+def test_distillation_end_to_end_two_epochs(tmp_path):
+    """Symbolic teacher (untrained, saved to disk) -> pixel student with the
+    distillation block; two PPO epochs must run and log losses/distill."""
+    import yaml
+    from rl_games.torch_runner import Runner
+    from rl_games.algos_torch.model_builder import ModelBuilder
+    tcfg = yaml.safe_load(open('rl_games/configs/craftax/ppo_craftax_classic_symbolic.yaml'))
+    net = ModelBuilder().load(tcfg['params'])
+    c = tcfg['params']['config']
+    teacher = net.build({'actions_num': 17, 'input_shape': (1345,), 'num_seqs': 1, 'value_size': 1,
+                         'normalize_value': c['normalize_value'], 'normalize_input': c['normalize_input']})
+    ck = tmp_path / 'teacher.pth'
+    torch.save({'model': teacher.state_dict(), 'epoch': 0}, ck)
+    scfg = yaml.safe_load(open('rl_games/configs/craftax/ppo_craftax_classic_pixels_distill.yaml'))
+    sc = scfg['params']['config']
+    sc.update(num_actors=16, horizon_length=8, minibatch_size=64, max_epochs=2, save_frequency=0,
+              train_dir=str(tmp_path), name='distill_smoke', device='cpu')
+    sc['central_value_config']['minibatch_size'] = 64
+    sc['distillation'].update(teacher_checkpoint=str(ck), beta=0.5)
+    sc['env_config'].update(device='cpu')
+    runner = Runner()
+    runner.load(scfg)
+    agent = runner.algo_factory.create(runner.algo_name, base_name='run', params=runner.params)
+    assert agent.distill is not None and agent.store_states
+    agent.train()
+    assert 'distill' in agent.aux_loss_dict

--- a/tests/test_craftax_env.py
+++ b/tests/test_craftax_env.py
@@ -64,6 +64,8 @@ def test_autoreset_and_achievements_info():
             seen = True
             assert info['achievements'].shape == (4, 22)
             assert torch.equal(info['done_mask'], d)
+            vals = torch.unique(info['achievements'][d]).tolist()
+            assert set(vals) <= {0.0, 1.0}, vals              # craftax reports 0/100; env rescales to 0/1
     assert seen
 
 

--- a/tests/test_distillation.py
+++ b/tests/test_distillation.py
@@ -112,3 +112,20 @@ def test_warm_start_copies_matching_tensors_only():
     assert copied == 4 and skipped == 2                           # extra.* skipped
     assert torch.equal(cv['trunk'].weight, teacher['trunk'].weight)
     assert torch.equal(cv['value'].bias, teacher['value'].bias)
+
+
+def test_teacher_mu_clip_bounds_continuous_targets():
+    t = _Teacher(4, 3, discrete=False, seed=3)
+    with torch.no_grad():
+        t.lin.weight.mul_(10.0)                       # teacher means far outside [-1, 1]
+    states = torch.randn(8, 4)
+    mus = torch.zeros(8, 3)
+    sig = torch.full((8, 3), 0.5)
+    with torch.no_grad():
+        tm = t.lin(states)
+    assert tm.abs().max() > 1.5
+    clipped = _distill(t, False, loss='mse', teacher_mu_clip=1.0).loss({'mus': mus, 'sigmas': sig}, states)
+    expected = (tm.clamp(-1.0, 1.0) ** 2).sum(-1).mean()
+    assert torch.allclose(clipped, expected, atol=1e-6)
+    unclipped = _distill(t, False, loss='mse').loss({'mus': mus, 'sigmas': sig}, states)
+    assert unclipped > clipped

--- a/tests/test_distillation.py
+++ b/tests/test_distillation.py
@@ -1,0 +1,114 @@
+"""Tests for rl_games/common/distillation.py (frozen-teacher distillation)."""
+
+import numpy as np
+import pytest
+import torch
+
+
+def test_piecewise_linear_schedule():
+    from rl_games.common.distillation import piecewise_linear
+    spec = [[0, 1.0], [10, 1.0], [20, 0.0]]
+    assert piecewise_linear(spec, -5) == 1.0
+    assert piecewise_linear(spec, 5) == 1.0
+    assert abs(piecewise_linear(spec, 15) - 0.5) < 1e-9
+    assert piecewise_linear(spec, 30) == 0.0
+    assert piecewise_linear(0.3, 7) == 0.3            # scalar spec = constant
+    assert piecewise_linear(None, 7) == 0.0
+
+
+class _Teacher(torch.nn.Module):
+    """Stand-in teacher: logits = W states (discrete) or mus = W states (continuous)."""
+
+    def __init__(self, in_dim, out_dim, discrete=True, seed=0):
+        super().__init__()
+        torch.manual_seed(seed)
+        self.lin = torch.nn.Linear(in_dim, out_dim)
+        self.discrete = discrete
+
+    def forward(self, d):
+        h = self.lin(d['obs'])
+        if self.discrete:
+            return {'logits': h}
+        return {'mus': h, 'sigmas': torch.full_like(h, 0.5)}
+
+
+def _distill(teacher, discrete, **cfg):
+    from rl_games.common.distillation import TeacherDistillation
+    base = {'coef': 1.0, 'ppo_coef': 1.0, 'beta': 0.0, 'loss': 'kl'}
+    base.update(cfg)
+    return TeacherDistillation(base, teacher, is_discrete=discrete, device='cpu')
+
+
+def test_discrete_kl_matches_manual_and_is_zero_for_identical():
+    t = _Teacher(4, 5)
+    d = _distill(t, True)
+    states = torch.randn(16, 4)
+    student_logits = torch.randn(16, 5)
+    with torch.no_grad():
+        p = torch.softmax(t.lin(states), -1)
+    manual = (p * (torch.log(p) - torch.log_softmax(student_logits, -1))).sum(-1).mean()
+    got = d.loss({'logits': student_logits}, states)
+    assert torch.allclose(got, manual, atol=1e-6)
+    with torch.no_grad():
+        same = d.loss({'logits': t.lin(states)}, states)
+    assert same.abs() < 1e-6
+    masks = torch.zeros(16, 1)
+    masks[:4] = 1
+    masked = d.loss({'logits': student_logits}, states, rnn_masks=masks)
+    manual_m = (p * (torch.log(p) - torch.log_softmax(student_logits, -1))).sum(-1)[:4].mean()
+    assert torch.allclose(masked, manual_m, atol=1e-6)
+
+
+def test_gaussian_kl_and_mse():
+    t = _Teacher(4, 3, discrete=False)
+    states = torch.randn(8, 4)
+    mus = torch.randn(8, 3)
+    sig = torch.full((8, 3), 0.8)
+    with torch.no_grad():
+        tm = t.lin(states)
+        ts = torch.full_like(tm, 0.5)
+    kl = (torch.log(sig / ts) + (ts ** 2 + (tm - mus) ** 2) / (2 * sig ** 2) - 0.5).sum(-1).mean()
+    assert torch.allclose(_distill(t, False).loss({'mus': mus, 'sigmas': sig}, states), kl, atol=1e-6)
+    mse = ((tm - mus) ** 2).sum(-1).mean()
+    assert torch.allclose(_distill(t, False, loss='mse').loss({'mus': mus, 'sigmas': sig}, states), mse, atol=1e-6)
+
+
+def test_mix_actions_substitutes_beta_rows_with_valid_neglogp():
+    torch.manual_seed(1)
+    t = _Teacher(4, 5)
+    d = _distill(t, True, beta=[[0, 1.0], [10, 0.0]])
+    N = 2000
+    states = torch.randn(N, 4)
+    logits = torch.randn(N, 5)
+    dist = torch.distributions.Categorical(logits=logits)
+    actions = dist.sample()
+    res = {'logits': logits, 'actions': actions.clone(), 'neglogpacs': -dist.log_prob(actions)}
+    out = d.mix_actions(res, states, epoch=5)                       # beta 0.5
+    changed = (out['actions'] != actions).float().mean().item()
+    assert 0.25 < changed < 0.55                                     # ~half the rows re-drawn from the teacher
+    assert torch.allclose(out['neglogpacs'], -dist.log_prob(out['actions']), atol=1e-5)
+    fresh = {'logits': logits, 'actions': actions.clone(), 'neglogpacs': -dist.log_prob(actions)}
+    untouched = d.mix_actions(fresh, states, epoch=20)              # beta 0
+    assert torch.equal(untouched['actions'], actions)
+    # continuous: substituted rows carry the student's Gaussian neglogp
+    tc = _Teacher(4, 3, discrete=False)
+    dc = _distill(tc, False, beta=1.0)
+    mus = torch.randn(N, 3)
+    sig = torch.full((N, 3), 0.7)
+    resc = {'mus': mus, 'sigmas': sig, 'actions': mus.clone(), 'neglogpacs': torch.zeros(N)}
+    outc = dc.mix_actions(resc, states, epoch=0)
+    ref = -torch.distributions.Normal(mus, sig).log_prob(outc['actions']).sum(-1)
+    assert torch.allclose(outc['neglogpacs'], ref, atol=1e-4)
+    assert not torch.allclose(outc['actions'], mus)
+
+
+def test_warm_start_copies_matching_tensors_only():
+    teacher = torch.nn.ModuleDict({'trunk': torch.nn.Linear(4, 8), 'value': torch.nn.Linear(8, 1),
+                                   'logits': torch.nn.Linear(8, 5)})
+    cv = torch.nn.ModuleDict({'trunk': torch.nn.Linear(4, 8), 'value': torch.nn.Linear(8, 1),
+                              'extra': torch.nn.Linear(2, 2)})
+    d = _distill(teacher, True)
+    copied, skipped = d.warm_start_central_value(cv)
+    assert copied == 4 and skipped == 2                           # extra.* skipped
+    assert torch.equal(cv['trunk'].weight, teacher['trunk'].weight)
+    assert torch.equal(cv['value'].bias, teacher['value'].bias)

--- a/tests/test_playground_env.py
+++ b/tests/test_playground_env.py
@@ -121,3 +121,21 @@ def test_continuous_distillation_end_to_end_cartpole(tmp_path):
     assert agent.distill is not None and not agent.distill.is_discrete
     agent.train()
     assert 'distill' in agent.aux_loss_dict
+
+
+@needs_playground
+def test_state_aux_end_to_end_cartpole(tmp_path):
+    """Pixel student + privileged-state auxiliary head (no teacher), two PPO epochs."""
+    import yaml
+    from rl_games.torch_runner import Runner
+    scfg = yaml.safe_load(open('rl_games/configs/playground/ppo_panda_pick_pixels_stateaux.yaml'))
+    sc = scfg['params']['config']
+    sc.update(num_actors=16, horizon_length=8, minibatch_size=64, max_epochs=2, save_frequency=0,
+              train_dir=str(tmp_path), name='pg_stateaux_smoke')
+    sc['env_config'].update(env_name='CartpoleBalance', cam_res=[32, 32], config_overrides={'episode_length': 20})
+    runner = Runner()
+    runner.load(scfg)
+    agent = runner.algo_factory.create(runner.algo_name, base_name='run', params=runner.params)
+    assert agent.store_states and agent.distill is None
+    agent.train()
+    assert 'state_aux' in agent.aux_loss_dict

--- a/tests/test_playground_env.py
+++ b/tests/test_playground_env.py
@@ -1,0 +1,91 @@
+"""Tests for the mujoco_playground vec env (JAX + Warp physics, built-in
+batch renderer). Needs the 3.11 venv with playground, warp-lang 1.16 and,
+under WSL2, the CUDA driver from /usr/lib/wsl/lib (preloaded by the env)."""
+
+import numpy as np
+import pytest
+import torch
+
+
+def _playground_ready():
+    """playground importable AND Warp sees a CUDA device (under WSL2 that needs
+    LD_LIBRARY_PATH=/usr/lib/wsl/lib so the driver's libcuda wins over the stub)."""
+    try:
+        import mujoco_playground, jax  # noqa: F401
+        import warp as wp
+        wp.init()
+        return len(wp.get_cuda_devices()) > 0
+    except Exception:
+        return False
+
+
+needs_playground = pytest.mark.skipif(not _playground_ready(),
+                                      reason='mujoco_playground unavailable or Warp has no CUDA device')
+
+
+def _make(n=8, **kw):
+    from rl_games.envs.playground_vecenv import PlaygroundVecEnv
+    cfg = dict(env_name='CartpoleBalance', obs='state', seed=1, device='cpu')
+    cfg.update(kw)
+    return PlaygroundVecEnv('playground', n, **cfg)
+
+
+@needs_playground
+def test_state_mode_shapes_and_time_outs():
+    env = _make(8, config_overrides={'episode_length': 20})
+    info = env.get_env_info()
+    assert info['action_space'].shape == (1,) and info['agents'] == 1
+    assert info['observation_space'].shape == info['state_space'].shape == (5,)
+    obs = env.reset()
+    assert torch.is_tensor(obs) and obs.shape == (8, 5) and obs.dtype == torch.float32
+    saw_timeout = False
+    for t in range(25):
+        obs, r, d, inf = env.step(torch.zeros(8, 1))
+        assert obs.shape == (8, 5) and r.shape == (8,) and r.dtype == torch.float32 and d.dtype == torch.bool
+        assert inf['time_outs'].shape == (8,)
+        if d.any():
+            saw_timeout = True
+            assert torch.equal(inf['time_outs'], d)          # balance task only ends by time limit
+            assert t == 19
+    assert saw_timeout
+
+
+@needs_playground
+def test_pixels_and_both_modes():
+    env = _make(4, obs='pixels', cam_res=(32, 32))
+    assert env.get_env_info()['observation_space'].shape == (32, 32, 3)
+    obs = env.reset()
+    assert obs.shape == (4, 32, 32, 3) and obs.dtype == torch.uint8 and int(obs.max()) > 0
+    env = _make(4, obs='both', cam_res=(32, 32))
+    info = env.get_env_info()
+    assert info['observation_space'].shape == (32, 32, 3) and info['state_space'].shape == (5,)
+    obs = env.reset()
+    assert obs['obs'].shape == (4, 32, 32, 3) and obs['states'].shape == (4, 5)
+    o, r, d, inf = env.step(torch.zeros(4, 1))
+    assert o['obs'].shape == (4, 32, 32, 3) and o['states'].dtype == torch.float32
+
+
+@needs_playground
+def test_metrics_reported_on_done_and_observer():
+    from rl_games.envs.playground_vecenv import PlaygroundObserver
+    env = _make(4, config_overrides={'episode_length': 10})
+    env.reset()
+    got = None
+    for _ in range(12):
+        _, _, d, inf = env.step(torch.zeros(4, 1))
+        if d.any():
+            got = inf
+            break
+    assert got is not None and 'metrics' in got and 'done_mask' in got
+    assert all(v.shape == (4,) for v in got['metrics'].values())
+
+    class _Algo:
+        writer = None
+        num_agents = 1
+
+    obs = PlaygroundObserver()
+    obs.after_init(_Algo())
+    obs.process_infos(got, torch.nonzero(d)[:, :1])
+    assert len(obs.episodes) == int(d.sum())
+    means = obs.means()
+    assert set(means) == set(got['metrics'])

--- a/tests/test_playground_env.py
+++ b/tests/test_playground_env.py
@@ -89,3 +89,35 @@ def test_metrics_reported_on_done_and_observer():
     assert len(obs.episodes) == int(d.sum())
     means = obs.means()
     assert set(means) == set(got['metrics'])
+
+
+@needs_playground
+def test_continuous_distillation_end_to_end_cartpole(tmp_path):
+    """Continuous-action distillation plumbing: untrained state teacher ->
+    pixel student on CartpoleBalance (fast vision env), two PPO epochs."""
+    import yaml
+    from rl_games.torch_runner import Runner
+    from rl_games.algos_torch.model_builder import ModelBuilder
+    tcfg = yaml.safe_load(open('rl_games/configs/playground/ppo_panda_pick_state.yaml'))
+    tcfg['params']['config']['env_config'].update(env_name='CartpoleBalance')
+    tpath = tmp_path / 'teacher_cfg.yaml'
+    yaml.safe_dump(tcfg, open(tpath, 'w'))
+    c = tcfg['params']['config']
+    teacher = ModelBuilder().load(tcfg['params']).build(
+        {'actions_num': 1, 'input_shape': (5,), 'num_seqs': 1, 'value_size': 1,
+         'normalize_value': c['normalize_value'], 'normalize_input': c['normalize_input']})
+    ck = tmp_path / 'teacher.pth'
+    torch.save({'model': teacher.state_dict(), 'epoch': 0}, ck)
+    scfg = yaml.safe_load(open('rl_games/configs/playground/ppo_panda_pick_pixels_distill.yaml'))
+    sc = scfg['params']['config']
+    sc.update(num_actors=16, horizon_length=8, minibatch_size=64, max_epochs=2, save_frequency=0,
+              train_dir=str(tmp_path), name='pg_distill_smoke')
+    sc['central_value_config']['minibatch_size'] = 64
+    sc['distillation'].update(teacher_config=str(tpath), teacher_checkpoint=str(ck), beta=0.5)
+    sc['env_config'].update(env_name='CartpoleBalance', cam_res=[32, 32], config_overrides={'episode_length': 20})
+    runner = Runner()
+    runner.load(scfg)
+    agent = runner.algo_factory.create(runner.algo_name, base_name='run', params=runner.params)
+    assert agent.distill is not None and not agent.distill.is_discrete
+    agent.train()
+    assert 'distill' in agent.aux_loss_dict

--- a/tests/test_state_aux.py
+++ b/tests/test_state_aux.py
@@ -1,0 +1,68 @@
+"""actor_critic_state_aux: pixel actor-critic with an auxiliary head that
+regresses the privileged state from the actor trunk (no teacher)."""
+
+import torch
+
+
+def _cfg(coef=1.0):
+    return {'model': {'name': 'continuous_a2c_logstd'},
+            'network': {'name': 'actor_critic_state_aux', 'separate': False,
+                        'state_aux': {'coef': coef, 'units': [32]},
+                        'space': {'continuous': {'mu_activation': 'None', 'sigma_activation': 'None',
+                                                 'mu_init': {'name': 'default'},
+                                                 'sigma_init': {'name': 'const_initializer', 'val': 0},
+                                                 'fixed_sigma': True}},
+                        'cnn': {'permute_input': True, 'type': 'conv2d', 'activation': 'elu',
+                                'initializer': {'name': 'default'}, 'regularizer': {'name': 'None'},
+                                'convs': [{'filters': 8, 'kernel_size': 5, 'strides': 2, 'padding': 0},
+                                          {'filters': 8, 'kernel_size': 3, 'strides': 2, 'padding': 0}]},
+                        'mlp': {'units': [32], 'activation': 'elu', 'initializer': {'name': 'default'}}}}
+
+
+def _build(coef=1.0, state_dim=7):
+    from rl_games.algos_torch.model_builder import ModelBuilder
+    return ModelBuilder().load(_cfg(coef)).build(
+        {'actions_num': 3, 'input_shape': (32, 32, 3), 'state_shape': (state_dim,), 'num_seqs': 1,
+         'value_size': 1, 'normalize_value': False, 'normalize_input': False})
+
+
+def test_state_aux_loss_present_in_train_and_grads_reach_cnn():
+    model = _build()
+    obs = torch.rand(6, 32, 32, 3)
+    states = torch.randn(6, 7)
+    model.train()
+    out = model({'obs': obs, 'states': states, 'is_train': True, 'prev_actions': torch.zeros(6, 3)})
+    aux = model.get_aux_loss()
+    assert aux is not None and 'state_aux' in aux and torch.isfinite(aux['state_aux'])
+    aux['state_aux'].backward()
+    conv_w = next(p for n, p in model.named_parameters() if 'actor_cnn' in n and p.dim() == 4)
+    assert conv_w.grad is not None and conv_w.grad.abs().sum() > 0
+    assert model.get_aux_loss() is None                      # consumed; not reused for the next step
+    assert 'mus' in out and out['mus'].shape == (6, 3)
+
+
+def test_state_aux_absent_without_states_and_scaled_by_coef():
+    model = _build(coef=1.0)
+    model.train()
+    model({'obs': torch.rand(4, 32, 32, 3), 'is_train': True, 'prev_actions': torch.zeros(4, 3)})
+    assert model.get_aux_loss() is None
+    torch.manual_seed(0)
+    m1 = _build(coef=1.0)
+    torch.manual_seed(0)
+    m2 = _build(coef=0.5)
+    obs = torch.rand(4, 32, 32, 3)
+    states = torch.randn(4, 7)
+    for m in (m1, m2):
+        m.train()
+        m({'obs': obs, 'states': states, 'is_train': True, 'prev_actions': torch.zeros(4, 3)})
+    assert torch.allclose(m1.get_aux_loss()['state_aux'], 2 * m2.get_aux_loss()['state_aux'], atol=1e-6)
+
+
+def test_state_aux_indices_subset():
+    from rl_games.algos_torch.model_builder import ModelBuilder
+    cfg = _cfg()
+    cfg['network']['state_aux']['indices'] = [0, 2, 4]
+    model = ModelBuilder().load(cfg).build(
+        {'actions_num': 3, 'input_shape': (32, 32, 3), 'state_shape': (7,), 'num_seqs': 1,
+         'value_size': 1, 'normalize_value': False, 'normalize_input': False})
+    assert model.a2c_network.aux_head[-1].out_features == 3


### PR DESCRIPTION
## Summary

Distillation from a frozen privileged-state teacher as a loss term inside the existing PPO agents, with weight schedules, so DAgger, DAgger → PPO fine-tune and teacher-guided RL are config variants of one mechanism. Plus two vision envs to try it on. Docs: `docs/DISTILLATION.md`.

### Mechanism — `rl_games/common/distillation.py`
- `distillation` block in the algo config: `teacher_config`, `teacher_checkpoint`, `loss` (discrete KL; continuous KL or MSE, with `teacher_mu_clip` to bound the targets) and three piecewise-linear epoch schedules: `coef` (distillation weight), `ppo_coef` (0 = pure DAgger), `beta` (P(env action from the teacher), student neglogp recomputed so PPO ratios stay valid).
- Agent hooks: `states` stored and passed into minibatches whenever distillation is on; action mixing in `get_action_values`; `loss = ppo_coef·ppo + coef·distill` in `calc_gradients`; central value warm-started from every teacher tensor with matching name and shape.

### Envs
- `CraftaxVecEnv` (`craftax`): Craftax-Classic in JAX, `obs: symbolic | pixels | both`, ~90k steps/s at 1024 envs, `CraftaxObserver` logs Crafter score.
- `PlaygroundVecEnv` (`playground`): any mujoco_playground env, `obs: state | pixels | both` via mujoco 3.12's built-in Warp batch renderer; Panda pick-cube ~30k steps/s (state) / ~7k (pixels) at 1024 worlds.

### Results (one seed each)
| task | student from scratch | distilled student | teacher |
|---|---|---|---|
| Craftax-Classic, 98M frames, reward | 16.1 | 16.5 (reaches 16.1 at 40M, ~2.5× fewer frames) | 17.0 |
| Panda pick-cube from 64×64 pixels, 9.8M frames, success | 0.00 | 1.00 (from 4M frames on) | 1.00 |

A third arm, the same pixel student with a privileged-state regression head instead of a teacher (`actor_critic_state_aux`, `state_aux: {}`), stays at 0.00 success: the state is decodable from pixels (normalised MSE 0.17) but the bottleneck is exploration, which only the teacher's actions supply.

Two things the Panda run needed: a fixed learning rate (the distillation term inflates the between-update KL and the adaptive schedule collapsed the lr to 5e-6) and clipping the teacher's means to the action range.

### Tests
`tests/test_distillation.py` (6), `tests/test_state_aux.py` (3), `tests/test_craftax_env.py` (5, incl. end-to-end discrete), `tests/test_playground_env.py` (5, incl. end-to-end continuous and state-aux); master PPO regression suites pass (78). The JAX env tests need the 3.11 venv (`jax[cuda12]`, craftax, playground, `warp-lang==1.16.0`; under WSL2 `LD_LIBRARY_PATH=/usr/lib/wsl/lib`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014VbqfktSeifgwrzHd8w1dL
